### PR TITLE
friendly_id設定変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'stl2gif', github: 'oshimaryo/stl2gif', branch: 'develop', ref: '2e508559aa3
 gem 'carrierwave_backgrounder', github: 'lardawge/carrierwave_backgrounder', ref: 'bff7bc3954b9184157812f948b9a6a4f64ff36d3'
 
 gem 'friendly_id', '~> 5.0.0'
-gem 'stringex', '2.5.2'
 
 gem 'truncate_html'
 gem 'clockwork'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,6 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stringex (2.5.2)
     subexec (0.2.3)
     sysexits (1.2.0)
     temple (0.8.0)
@@ -495,7 +494,6 @@ DEPENDENCIES
   spring-commands-rspec
   stl!
   stl2gif!
-  stringex (= 2.5.2)
   truncate_html
   turbolinks (~> 2.5, >= 2.5.3)
   uglifier

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,7 +1,0 @@
-FriendlyId.defaults do |config|
-  config.use Module.new {
-    def normalize_friendly_id(text)
-      text.to_url
-    end
-  }
-end


### PR DESCRIPTION
stringexを利用したfriendly_idの日本語対応が行われていたが、そもそも日本語が入るパターンが存在しないため、この対応を削除する。（また、なぜかはわかっていないのだが、このinitializerで定義したメソッドは使われていなかった。）

friendly_idが使われているのは以下の3つ
https://github.com/takeyuwebinc/gitfab2/blob/bc53c87b7b989996e927e9d67f170c595df0a86c/app/models/project.rb#L10-L11
https://github.com/takeyuwebinc/gitfab2/blob/b4bd18e3803de6fd1de98259b0f61d54633e4f7e/app/models/group.rb#L8-L9
https://github.com/takeyuwebinc/gitfab2/blob/2d5632fc9b34c62f7bab99bf9a9fb21ee0c37e47/app/models/user.rb#L7-L8

また、全てのnameカラムは `NameFormatValidator` によってローマ字・数字・ハイフン以外のものが含まれないようになっている
https://github.com/takeyuwebinc/gitfab2/blob/df82cef502973b9fcb98b424c2517bd97ee7bc2a/app/validators/name_format_validator.rb#L1-L7
https://github.com/takeyuwebinc/gitfab2/blob/bc53c87b7b989996e927e9d67f170c595df0a86c/app/models/project.rb#L29
https://github.com/takeyuwebinc/gitfab2/blob/b4bd18e3803de6fd1de98259b0f61d54633e4f7e/app/models/group.rb#L16
https://github.com/takeyuwebinc/gitfab2/blob/2d5632fc9b34c62f7bab99bf9a9fb21ee0c37e47/app/models/user.rb#L23-L24

ちなみに `Project` の `name` は `title` （これは日本語入力可能）から作られるのだが、日本語は全て `'x'` で置き換えられる仕様になっているので、フォーム経由で `name` に日本語が入ることはない。
https://github.com/takeyuwebinc/gitfab2/blob/0f0a13dca01617c059382fb9a2db4c6b31c5dd83/app/controllers/projects_controller.rb#L31-L33