### PR TITLE
コメント(CardComment)にて文字数が多い時にはみ出してしまっていたのを修正

### DIFF
--- a/app/assets/stylesheets/projects/comment.scss
+++ b/app/assets/stylesheets/projects/comment.scss
@@ -109,6 +109,7 @@
           font-family: $common-novelsans-light;
           font-size: 12px;
           line-height: 19px;
+          word-wrap: break-word;
           a {
             color: $common-dark-blue;
           }


### PR DESCRIPTION


before

![2018-08-20 18 55 05](https://user-images.githubusercontent.com/5820754/44348575-c54dce00-a4d5-11e8-8576-cc0029c87991.png)

after

![2018-08-21 0 01 25](https://user-images.githubusercontent.com/5820754/44348583-d0086300-a4d5-11e8-963e-dc505f07aa32.png)
