### PR TITLE
Remove yield :utils

### DIFF
--- a/app/views/layouts/dashboard.html.slim
+++ b/app/views/layouts/dashboard.html.slim
@@ -12,5 +12,4 @@
 - content_for :content do
   #content
     = yield
-    = yield :utils
 = render "layouts/base_layout"

--- a/app/views/layouts/global_projects.html.slim
+++ b/app/views/layouts/global_projects.html.slim
@@ -7,5 +7,4 @@
 
 - content_for :content do
   = yield
-  = yield :utils
 = render "layouts/base_layout"

--- a/app/views/layouts/recipe.html.slim
+++ b/app/views/layouts/recipe.html.slim
@@ -5,5 +5,4 @@
 - content_for :content do
   #content.recipe-layout
     = yield
-    = yield :utils
 = render "layouts/base_layout"

--- a/app/views/layouts/static_pages.html.slim
+++ b/app/views/layouts/static_pages.html.slim
@@ -8,5 +8,4 @@
 - content_for :content do
   #content
     = yield
-    = yield :utils
 = render "layouts/base_layout"


### PR DESCRIPTION
対応する`content_for :utils`はどこにも無い・・・

もともと #36 でやっていたが、よく考えたらその件とは関係がないのでこちらに切り出した

`layouts/global_projects.html.slim` は #36 で削除予定だが、このブランチ上ではまだなので対応した
