### PR TITLE
Delete `More Projects` link

### DIFF
--- a/app/assets/stylesheets/projects/index.scss
+++ b/app/assets/stylesheets/projects/index.scss
@@ -394,20 +394,6 @@
           }
         }
       }
-
-      .more {
-        margin: 20px 20px 0 0;
-        .more-projects {
-          display: block;
-          padding: 10px 10px 5px;
-          width: 140px;
-          height: 20px;
-          background: $common-basic-color;
-          color: $common-btn-text-color;
-          font-size: 17.5px;
-          border-radius: 5px;
-        }
-      }
     }
   }
 

--- a/app/views/projects/_recent_projects.html.slim
+++ b/app/views/projects/_recent_projects.html.slim
@@ -3,8 +3,3 @@
     ul#recent-projects.projects
       - @projects.each do |project|
         = render "project", project: project
-
-    - if @projects.present? && @projects.count > 12
-
-      .more
-        = link_to "→ More Projects", "/?page=2&q=", class: "more-projects"


### PR DESCRIPTION
Closes #46 

プロジェクト一覧、「最近のプロジェクト」の下部に `More Projects` リンクを表示した
検索画面の２ページ目へと遷移する

![2018-08-23 22 49 05](https://user-images.githubusercontent.com/5820754/44529417-02f56580-a727-11e8-9cac-e524eb060755.png)
