### PR TITLE
Remove :show from before_action :load_group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,7 @@ class GroupsController < ApplicationController
   layout 'groups'
 
   before_action :build_group, only: [:new, :create]
-  before_action :load_group, only: [:show, :edit, :update, :destroy]
+  before_action :load_group, only: [:edit, :update, :destroy]
 
   authorize_resource
 


### PR DESCRIPTION
action ':show' could not be found in GroupsController

現在 `GroupsController` に `show` actionはないので削除しました
