### PR TITLE
Fix path to edit user

### DIFF
--- a/app/views/layouts/_setting_links.html.slim
+++ b/app/views/layouts/_setting_links.html.slim
@@ -2,7 +2,7 @@
   .user-account.account
     h1.title ACCOUNT
     .user
-      = link_to [:edit, current_user] do
+      = link_to edit_user_path do
         .inner
           = image_tag current_user.avatar.thumb.url, class: "avatar"
           .name


### PR DESCRIPTION
`current_user` をパスに渡す必要は無くなったため、ユーザープロフィール編集画面左上のACCOUNT欄にあるパスを修正

before

![2018-08-31 13 46 22](https://user-images.githubusercontent.com/5820754/44893305-62ee9c00-ad25-11e8-8bd8-53c1c33da5ad.png)

after

![2018-08-31 13 47 34](https://user-images.githubusercontent.com/5820754/44893318-713cb800-ad25-11e8-84c6-41f6ad5f87ea.png)
