### PR TITLE
Fix Groups#index

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,7 @@ class GroupsController < ApplicationController
   authorize_resource
 
   def index
-    @groups = Group.all
+    @groups = current_user.groups
   end
 
   def new

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -5,7 +5,7 @@
     h1
       'Groups
     ul#groups
-      - current_user.groups.each do |group|
+      - @groups.each do |group|
         = render "group", group: group
 
 


### PR DESCRIPTION
もともと`groups/index.html.slim`では`current_user`の`groups`しか表示されていなかった
にもかかわらず、`Groups#index`では`Group.all`で全グループを取得していた

`current_user.groups`のみを取得するようにした

現在の`/groups` の画面

![2018-08-31 16 02 16](https://user-images.githubusercontent.com/5820754/44897666-6be86900-ad37-11e8-9107-fd77827bef08.png)
