### PR TITLE
Fix groups_controller

### DIFF
--- a/app/assets/stylesheets/groups/_form.scss
+++ b/app/assets/stylesheets/groups/_form.scss
@@ -17,6 +17,11 @@
     margin-bottom: 20px;
   }
 
+  #alert {
+    color: $common-error-text-color;
+    margin-bottom: 20px;
+  }
+
   .page-title {
     padding: 20px 0;
     font-weight: normal;

--- a/app/assets/stylesheets/groups/_form.scss
+++ b/app/assets/stylesheets/groups/_form.scss
@@ -23,7 +23,7 @@
   }
 
   .page-title {
-    padding: 20px 0;
+    margin: 10px 0 30px;
     font-weight: normal;
     font-size: 30px;
   }
@@ -78,7 +78,7 @@
 
   #submit {
     @include clickable;
-    margin: 60px 0 20px;
+    margin-top: 40px;
     padding: 5px 68px;
     font-size: 18px;
     color: $common-btn-text-color;

--- a/app/assets/stylesheets/groups/edit.scss
+++ b/app/assets/stylesheets/groups/edit.scss
@@ -84,8 +84,11 @@
       }
     }
 
-    #new-membership {
+    #new-membership, #delete-group {
       margin-top: 55px;
+    }
+
+    #new-membership {
       #s2id_member_name {
         margin: 20px 0px;
         font-family: $common-novelsans-semibold;
@@ -107,6 +110,17 @@
         @include clickable;
         font-size: 12px;
         background: $common-basic-color;
+        border: none;
+      }
+    }
+
+    #delete-group {
+      #delete-btn {
+        @include clickable;
+        margin: 60px 0 20px;
+        padding: 5px 68px;
+        font-size: 18px;
+        color: $common-btn-text-color;
         border: none;
       }
     }

--- a/app/assets/stylesheets/groups/edit.scss
+++ b/app/assets/stylesheets/groups/edit.scss
@@ -10,19 +10,19 @@
   #edit-members {
     display: block;
     margin-bottom: $common-margin-for-footer;
-    padding: 20px 0;
-    width: 730px;
+    padding: 20px;
+    width: 690px;
     font-family: $common-novelsans-semibold;
     background-color: $common-background-color;
     border-radius: 5px;
-    .inner {
-      padding: 30px 20px 20px;
-    }
     .title{
       padding: 10px 0;
-      font-size: 30px;
+      font-size: 26px;
       font-weight: normal;
       border-bottom: 1px solid $common-gray;
+    }
+    .body {
+      margin-top: 15px;
     }
     ul#members{
       li.membership {
@@ -85,7 +85,7 @@
     }
 
     #new-membership, #delete-group {
-      margin-top: 55px;
+      margin-top: 40px;
     }
 
     #new-membership {
@@ -117,9 +117,8 @@
     #delete-group {
       #delete-btn {
         @include clickable;
-        margin: 60px 0 20px;
-        padding: 5px 68px;
-        font-size: 18px;
+        padding: 3px 30px;
+        font-size: 14px;
         color: $common-btn-text-color;
         border: none;
       }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,7 @@ class ApplicationController < ActionController::Base
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActionController::RoutingError, with: :render_404
   end
-
-  rescue_from CanCan::AccessDenied do
-    render_401
-  end
+  rescue_from CanCan::AccessDenied, with: :render_401
 
   after_action :store_location
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do
-    render file: "public/401.html", status: :unauthorized
+    render_401
   end
 
   after_action :store_location
@@ -26,8 +26,16 @@ class ApplicationController < ActionController::Base
     @current_user = user
   end
 
+  def render_401(layout: false)
+    render file: Rails.root.join('public/401.html'), status: :unauthorized, layout: layout, content_type: 'text/html'
+  end
+
   def render_403(layout: false)
     render file: Rails.root.join('public/403.html'), status: :forbidden, layout: layout, content_type: 'text/html'
+  end
+
+  def render_404(layout: false)
+    render file: Rails.root.join('public/404.html'), status: :not_found, layout: layout, content_type: 'text/html'
   end
 
   private
@@ -37,14 +45,6 @@ class ApplicationController < ActionController::Base
       return if request.xhr?
       return if ['/users/auth/github', '/users/new', '/users/sign_out', '/sessions'].include?(request.path)
       session[:previous_url] = request.fullpath
-    end
-
-    def render_401(_exception = nil)
-      render file: Rails.root.join('public/401.html'), status: 401, layout: false, content_type: 'text/html'
-    end
-
-    def render_404(_exception = nil)
-      render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
     end
 
     def render_500(exception = nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,15 +27,15 @@ class ApplicationController < ActionController::Base
   end
 
   def render_401(layout: false)
-    render file: Rails.root.join('public/401.html'), status: :unauthorized, layout: layout, content_type: 'text/html'
+    render file: Rails.root.join('public/401.html'), status: :unauthorized, layout: layout
   end
 
   def render_403(layout: false)
-    render file: Rails.root.join('public/403.html'), status: :forbidden, layout: layout, content_type: 'text/html'
+    render file: Rails.root.join('public/403.html'), status: :forbidden, layout: layout
   end
 
   def render_404(layout: false)
-    render file: Rails.root.join('public/404.html'), status: :not_found, layout: layout, content_type: 'text/html'
+    render file: Rails.root.join('public/404.html'), status: :not_found, layout: layout
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     @current_user = user
   end
 
+  def render_403(layout: false)
+    render file: Rails.root.join('public/403.html'), status: :forbidden, layout: layout, content_type: 'text/html'
+  end
+
   private
 
     def store_location
@@ -37,10 +41,6 @@ class ApplicationController < ActionController::Base
 
     def render_401(_exception = nil)
       render file: Rails.root.join('public/401.html'), status: 401, layout: false, content_type: 'text/html'
-    end
-
-    def render_403(_exception = nil)
-      render file: Rails.root.join('public/403.html'), status: 403, layout: false, content_type: 'text/html'
     end
 
     def render_404(_exception = nil)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -59,13 +59,7 @@ class GroupsController < ApplicationController
   private
 
     def group_params
-      if params[:group]
-        params.require(:group).permit Group::UPDATABLE_COLUMNS + additional_params
-      end
-    end
-
-    def additional_params
-      [:id, member_ids: []]
+      params.require(:group).permit(:name, :avatar, :url, :location)
     end
 
     def get_group(id)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -59,7 +59,7 @@ class GroupsController < ApplicationController
   private
 
     def group_params
-      params.require(:group).permit(:name, :avatar, :url, :location)
+      params.require(:group).permit(:name, :avatar, :avatar_cache, :url, :location)
     end
 
     def get_group(id)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -37,14 +37,9 @@ class GroupsController < ApplicationController
   end
 
   def destroy
-    unless @group.deletable?
-      redirect_to [:edit, @group], alert: 'This group still has projects.'
-      return
-    end
-
     @group.soft_destroy!
     redirect_to :groups
-  rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed
+  rescue ActiveRecord::RecordNotSaved
     redirect_to [:edit, @group], alert: 'Group was not deleted.'
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -32,7 +32,7 @@ class GroupsController < ApplicationController
   def update
     @group = get_group(params[:id])
     if can?(:update, @group)
-      if @group.update_attributes(group_params)
+      if @group.update(group_params)
         redirect_to edit_group_path(@group), notice: 'Group profile was successfully updated.'
       else
         render :edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
   def edit
     @group = get_group(params[:id])
     unless can?(:edit, @group)
-      render_forbidden
+      render_403(layout: true)
     end
   end
 
@@ -38,7 +38,7 @@ class GroupsController < ApplicationController
         render :edit
       end
     else
-      render_forbidden
+      render_403(layout: true)
     end
   end
 
@@ -52,7 +52,7 @@ class GroupsController < ApplicationController
         redirect_to edit_group_path(group), alert: 'Group was not deleted.'
       end
     else
-      render_forbidden
+      render_403(layout: true)
     end
   end
 
@@ -70,9 +70,5 @@ class GroupsController < ApplicationController
 
     def get_group(id)
       current_user.groups.active.friendly.find(id)
-    end
-
-    def render_forbidden
-      render file: "public/403.html", status: :forbidden
     end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
   before_action :forbidden, only: [:edit, :update, :destroy]
 
   def index
-    @groups = current_user.groups
+    @groups = current_user.groups.active
   end
 
   def new
@@ -56,7 +56,7 @@ class GroupsController < ApplicationController
     end
 
     def load_group
-      @group = current_user.groups.friendly.find params[:id]
+      @group = current_user.groups.active.friendly.find params[:id]
     end
 
     def forbidden

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,14 +23,14 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = load_group
+    @group = get_group(params[:id])
     unless can?(:edit, @group)
       render_forbidden
     end
   end
 
   def update
-    @group = load_group
+    @group = get_group(params[:id])
     if can?(:update, @group)
       if @group.update_attributes(group_params)
         redirect_to edit_group_path(@group), notice: 'Group profile was successfully updated.'
@@ -43,7 +43,7 @@ class GroupsController < ApplicationController
   end
 
   def destroy
-    group = load_group
+    group = get_group(params[:id])
     if can?(:destroy, group)
       begin
         group.soft_destroy!
@@ -68,8 +68,8 @@ class GroupsController < ApplicationController
       [:id, member_ids: []]
     end
 
-    def load_group
-      current_user.groups.active.friendly.find params[:id]
+    def get_group(id)
+      current_user.groups.active.friendly.find(id)
     end
 
     def render_forbidden

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,6 +1,6 @@
 class OwnersController < ApplicationController
   def index
-    @owners = User.order(name: :asc).all + Group.order(name: :asc).all
+    @owners = User.order(name: :asc).all + Group.active.order(name: :asc).all
   end
 
   def show

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -35,6 +35,8 @@ class Group < ApplicationRecord
 
   validates :name, presence: true, unique_owner_name: true, name_format: true
 
+  scope :active, -> { where(is_deleted: false) }
+
   Membership::ROLE.keys.each do |role|
     define_method role.to_s.pluralize do
       members.where('memberships.role' => Membership::ROLE[role])

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -47,14 +47,10 @@ class Group < ApplicationRecord
     end
   end
 
-  def deletable?
-    projects.none? || projects.pluck(:is_deleted).all?
-  end
-
   def soft_destroy!
     transaction do
       update!(is_deleted: true)
-      collaborations.destroy_all
+      projects.where(is_deleted: false).update_all(is_deleted: true)
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,7 @@
 #
 #  id             :integer          not null, primary key
 #  avatar         :string(255)
+#  is_deleted     :boolean          default(FALSE), not null
 #  location       :string(255)
 #  name           :string(255)
 #  projects_count :integer          default(0), not null
@@ -43,6 +44,17 @@ class Group < ApplicationRecord
   concerning :Draft do
     def generate_draft
       "#{name}\n#{url}\n#{location}"
+    end
+  end
+
+  def deletable?
+    projects.none? || projects.pluck(:is_deleted).all?
+  end
+
+  def soft_destroy!
+    transaction do
+      update!(is_deleted: true)
+      collaborations.destroy_all
     end
   end
 

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -7,6 +7,6 @@ class Owner
   end
 
   def self.find_by(slug)
-    User.find_by(slug: slug) || Group.find_by(slug: slug)
+    User.find_by(slug: slug) || Group.active.find_by(slug: slug)
   end
 end

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -15,6 +15,7 @@
 
   .right
     = f.file_field :avatar, id: "group-avatar-form"
+    = f.hidden_field :avatar_cache
     = link_to "Upload new picture", "#", id: "upload-button", class: "btn"
     = f.text_field :name, placeholder: "Name", id: "group-name-form", class: "text-form"
     = f.url_field :url, placeholder: "URL", class: "text-form"

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -1,5 +1,6 @@
 = form_for @group, class: "group-form" do |f|
-  p#notice = notice
+  - flash.each do |key, value|
+    = content_tag(:p, value, id: key)
 
   - if @group.errors.any?
     #error_explanation

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -9,7 +9,7 @@
   #edit-members
     .inner
       h1.title
-       'Members
+        'Members
       ul#members
         - @group.members.each do |member|
           = render "membership", membership: member.membership_in(@group)
@@ -23,7 +23,12 @@
           = select_tag :role, options_for_select(Membership::ROLE)
           = submit_tag "add", id: "add-btn", class: "btn"
 
-- content_for :bottom
+        #delete-group
+          h2.title
+            'Delete this group
+          = link_to "Delete", group_path(@group), method: :delete, class: "btn", id: "delete-btn", data: { confirm: "Are you sure to delete this group?" }
+
+        - content_for :bottom
 
   coffee:
     $(document).on "click", "#group-avatar", (event) ->

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -28,7 +28,7 @@
             'Delete this group
           = link_to "Delete", group_path(@group), method: :delete, class: "btn", id: "delete-btn", data: { confirm: "Are you sure to delete this group?" }
 
-        - content_for :bottom
+- content_for :bottom
 
   coffee:
     $(document).on "click", "#group-avatar", (event) ->

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -7,25 +7,26 @@
     = render "form"
 
   #edit-members
-    .inner
-      h1.title
-        'Members
-      ul#members
-        - @group.members.each do |member|
-          = render "membership", membership: member.membership_in(@group)
+    h2.title
+      'Members
+    ul#members
+      - @group.members.each do |member|
+        = render "membership", membership: member.membership_in(@group)
 
-      - if can? :manage, @group
-        #new-membership
-          h2.title
-            'Add Member
+    - if can? :manage, @group
+      #new-membership
+        h2.title
+          'Add Member
+        .body
           = form_tag group_members_path(group_id: @group.id), method: "post", id: "new_member", remote: true
           = select_tag :member_name
           = select_tag :role, options_for_select(Membership::ROLE)
           = submit_tag "add", id: "add-btn", class: "btn"
 
-        #delete-group
-          h2.title
-            'Delete this group
+      #delete-group
+        h2.title
+          'Delete this group
+        .body
           = link_to "Delete", group_path(@group), method: :delete, class: "btn", id: "delete-btn", data: { confirm: "Are you sure to delete this group?" }
 
 - content_for :bottom

--- a/app/views/layouts/_setting_links.html.slim
+++ b/app/views/layouts/_setting_links.html.slim
@@ -13,7 +13,7 @@
     = link_to image_tag("create-group.png"), [:new, :group], class: "create-group-btn"
 
     ul.groups
-      - current_user.groups.each do |group|
+      - current_user.groups.active.each do |group|
         = link_to [:edit, group] do
           li.group
             .inner

--- a/app/views/owners/show.html.slim
+++ b/app/views/owners/show.html.slim
@@ -55,7 +55,7 @@
           - if current_user && current_user == @owner
             = link_to image_tag("create-group.png"), [:new, :group], class: "create-group-btn"
           ul.groups
-            - @owner.groups.each do |group|
+            - @owner.groups.active.each do |group|
               = link_to owner_path(owner_name: group.slug) do
                 li.group
                   = image_tag group.avatar.url, class: "group-avatar", name: "#{group.name}"

--- a/db/migrate/20180912105807_add_is_deleted_to_group.rb
+++ b/db/migrate/20180912105807_add_is_deleted_to_group.rb
@@ -1,0 +1,5 @@
+class AddIsDeletedToGroup < ActiveRecord::Migration[5.2]
+  def change
+    add_column :groups, :is_deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_061610) do
     t.integer "projects_count", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "is_deleted", default: false, null: false
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -120,6 +120,7 @@ describe AnnotationsController, type: :controller do
           xhr: true
       end
       it { expect(response.status).to eq(404) }
+      it { expect(response).to render_template(layout: false) }
     end
   end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -60,7 +60,7 @@ describe GroupsController, type: :controller do
         other.memberships.create(group: group, role: 'editor')
       end
 
-      it { is_expected.to have_http_status :unauthorized }
+      it { is_expected.to have_http_status :forbidden }
     end
   end
 
@@ -106,34 +106,88 @@ describe GroupsController, type: :controller do
         expect { subject }.not_to change { group.reload.name }
       end
 
-      it { is_expected.to have_http_status :unauthorized }
+      it { is_expected.to have_http_status :forbidden }
     end
   end
 
   describe 'DELETE destroy' do
     subject { delete :destroy, params: { id: group } }
+    before { user.memberships.create(group_id: group.id, role: 'admin') }
 
     describe 'as an admin' do
       let!(:group) { FactoryBot.create :group }
 
-      before do
-        sign_in user
-        user.memberships.create(group_id: group.id, role: 'admin')
-      end
+      before { sign_in user }
 
       it { is_expected.to have_http_status :redirect }
-      it { expect{ subject }.to change{ Group.count }.by(-1) }
+      it { expect { subject }.to change { group.reload.is_deleted }.from(false).to(true) }
     end
 
     describe 'as an editor' do
       before do
         sign_in other
-        user.memberships.create(group_id: group.id, role: 'admin')
         other.memberships.create(group_id: group.id, role: 'editor')
       end
 
-      it { is_expected.to have_http_status :unauthorized }
-      it { expect{ subject }.to change{ Group.count }.by(0) }
+      it { is_expected.to have_http_status :forbidden }
+      it { expect { subject }.not_to change { group.reload.is_deleted } }
+    end
+
+    describe 'collaborations' do
+      before do
+        sign_in user
+        FactoryBot.create_list(:collaboration, 2, owner: group)
+      end
+
+      it { expect { subject }.to change { Collaboration.count }.to(0) }
+    end
+
+    describe 'projects' do
+      before do
+        sign_in user
+        FactoryBot.create_list(:project, 2, owner: group)
+      end
+
+      context 'when a group has projects' do
+        it { is_expected.to redirect_to [:edit, group] }
+        it { expect { subject }.not_to change { group.reload.is_deleted } }
+      end
+
+      context 'when a group has NO projects' do
+        before { group.projects.destroy_all }
+        it { is_expected.to redirect_to :groups }
+        it { expect { subject }.to change { group.reload.is_deleted }.from(false).to(true) }
+      end
+
+      context 'when projects are soft deleted' do
+        before { group.projects.update_all(is_deleted: true) }
+        it { is_expected.to redirect_to :groups }
+        it { expect { subject }.to change { group.reload.is_deleted }.from(false).to(true) }
+      end
+    end
+
+    describe 'raise on soft_destroy!' do
+      before do
+        sign_in user
+        FactoryBot.create_list(:collaboration, 2, owner: group)
+        allow_any_instance_of(Group).to receive(:soft_destroy!).and_raise(error)
+      end
+
+      shared_examples_for 'rescue' do
+        it { is_expected.to redirect_to [:edit, group] }
+        it { expect { subject }.not_to change { group.reload.is_deleted } }
+        it { expect { subject }.not_to change { Collaboration.count } }
+      end
+
+      describe 'ActiveRecord::RecordNotSaved' do
+        let(:error) { ActiveRecord::RecordNotSaved }
+        include_examples 'rescue'
+      end
+
+      describe 'ActiveRecord::RecordNotDestroyed' do
+        let(:error) { ActiveRecord::RecordNotDestroyed }
+        include_examples 'rescue'
+      end
     end
   end
 end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -74,6 +74,7 @@ describe GroupsController, type: :controller do
       end
 
       it { is_expected.to have_http_status :forbidden }
+      it { is_expected.not_to render_template(layout: false) }
     end
   end
 
@@ -120,6 +121,7 @@ describe GroupsController, type: :controller do
       end
 
       it { is_expected.to have_http_status :forbidden }
+      it { is_expected.not_to render_template(layout: false) }
     end
   end
 
@@ -143,6 +145,7 @@ describe GroupsController, type: :controller do
       end
 
       it { is_expected.to have_http_status :forbidden }
+      it { is_expected.not_to render_template(layout: false) }
       it { expect { subject }.not_to change { group.reload.is_deleted } }
     end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -10,11 +10,22 @@ describe GroupsController, type: :controller do
   subject { response }
 
   describe 'GET index' do
-    before do
-      sign_in user
-      get :index
-    end
+    subject { get :index }
+    before { sign_in user }
+
     it { is_expected.to render_template :index }
+
+    context 'when active and deleted projects' do
+      before do
+        user.memberships.create(group: FactoryBot.create(:group, is_deleted: false))
+        user.memberships.create(group: FactoryBot.create(:group, is_deleted: true))
+      end
+
+      it 'fetches active projects only' do
+        subject
+        expect(assigns(:groups)).to be_all { |g| g.is_deleted == false }
+      end
+    end
   end
 
   describe 'GET new' do

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -5,6 +5,7 @@
 #
 #  id             :integer          not null, primary key
 #  avatar         :string(255)
+#  is_deleted     :boolean          default(FALSE), not null
 #  location       :string(255)
 #  name           :string(255)
 #  projects_count :integer          default(0), not null

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -30,4 +30,58 @@ describe Group do
     end
     it { is_expected.to be true }
   end
+
+  describe '#deletable?' do
+    subject { group.deletable? }
+    let(:group) { FactoryBot.create :group }
+
+    it { is_expected.to eq true }
+
+    context 'when group has projects' do
+      before { FactoryBot.create(:project, owner: group) }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when projects are all deleted' do
+      before { FactoryBot.create_list(:project, 2, owner: group, is_deleted: true) }
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe '#soft_destroy!' do
+    subject { group.soft_destroy! }
+    let(:group) { FactoryBot.create(:group) }
+    let(:collaborations) { FactoryBot.create_list(:collaboration, 2, owner: group) }
+
+    it { expect { subject }.to change { group.is_deleted }.from(false).to(true) }
+    it { expect { subject }.to change { group.collaborations.count }.by(0) }
+
+    context 'when failing to update group' do
+      before { allow(group).to receive(:update!).and_raise(ActiveRecord::RecordNotSaved) }
+
+      it 'does NOT delete group' do
+        expect do
+          begin
+            subject
+          rescue ActiveRecord::RecordNotSaved => _
+          end
+        end.not_to change { group.is_deleted }
+      end
+    end
+
+    context 'when failing to delete all collaborations' do
+      before { allow(Collaboration).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed) }
+
+      it 'does NOT delete collaborations' do
+        expect do
+          begin
+            subject
+          rescue ActiveRecord::RecordNotDestroyed => _
+          end
+        end.not_to change { group.collaborations.count }
+      end
+    end
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -46,12 +46,9 @@ describe Group do
 
   describe '#active' do
     subject { Group.active }
+    let!(:active) { FactoryBot.create(:group, is_deleted: false) }
+    let!(:deleted) { FactoryBot.create(:group, is_deleted: true) }
 
-    before do
-      FactoryBot.create_list(:group, 2, is_deleted: false)
-      FactoryBot.create_list(:group, 2, is_deleted: true)
-    end
-
-    it { is_expected.to eq Group.where(is_deleted: false) }
+    it { is_expected.to eq [active] }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -43,4 +43,15 @@ describe Group do
       expect(group.projects).to be_all { |p| p.is_deleted? }
     end
   end
+
+  describe '#active' do
+    subject { Group.active }
+
+    before do
+      FactoryBot.create_list(:group, 2, is_deleted: false)
+      FactoryBot.create_list(:group, 2, is_deleted: true)
+    end
+
+    it { is_expected.to eq Group.where(is_deleted: false) }
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -31,57 +31,16 @@ describe Group do
     it { is_expected.to be true }
   end
 
-  describe '#deletable?' do
-    subject { group.deletable? }
-    let(:group) { FactoryBot.create :group }
-
-    it { is_expected.to eq true }
-
-    context 'when group has projects' do
-      before { FactoryBot.create(:project, owner: group) }
-
-      it { is_expected.to eq false }
-    end
-
-    context 'when projects are all deleted' do
-      before { FactoryBot.create_list(:project, 2, owner: group, is_deleted: true) }
-
-      it { is_expected.to eq true }
-    end
-  end
-
   describe '#soft_destroy!' do
     subject { group.soft_destroy! }
-    let(:group) { FactoryBot.create(:group) }
-    let(:collaborations) { FactoryBot.create_list(:collaboration, 2, owner: group) }
+
+    let!(:group) { FactoryBot.create(:group) }
+    before { FactoryBot.create_list(:project, 2, owner: group, is_deleted: false) }
 
     it { expect { subject }.to change { group.is_deleted }.from(false).to(true) }
-    it { expect { subject }.to change { group.collaborations.count }.by(0) }
-
-    context 'when failing to update group' do
-      before { allow(group).to receive(:update!).and_raise(ActiveRecord::RecordNotSaved) }
-
-      it 'does NOT delete group' do
-        expect do
-          begin
-            subject
-          rescue ActiveRecord::RecordNotSaved => _
-          end
-        end.not_to change { group.is_deleted }
-      end
-    end
-
-    context 'when failing to delete all collaborations' do
-      before { allow(Collaboration).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed) }
-
-      it 'does NOT delete collaborations' do
-        expect do
-          begin
-            subject
-          rescue ActiveRecord::RecordNotDestroyed => _
-          end
-        end.not_to change { group.collaborations.count }
-      end
+    it 'deletes all projects' do
+      subject
+      expect(group.projects).to be_all { |p| p.is_deleted? }
     end
   end
 end


### PR DESCRIPTION
~~adminが一人の時のみgroupを削除できるようにした~~

編集画面に削除ボタンを追加

![image](https://user-images.githubusercontent.com/5820754/44977586-65f6c000-afa3-11e8-819b-e6a84f865d0b.png)


重要な操作なので 一番下にした。スタイルは `Save` buttonに合わせている
ボタンのサイズ、マージン共に大きいので浮いた感じになったが、重要なのでむしろ浮いていたほうがいいのでは、と思いました

（メモ転記）
- [x] Project ownerになっているGroupは削除不可
- [x] Group#membersが空のGroupは生まれないようにする
- [x] Group#membersにMembership#roleがadminなUserが最低一人いるようにする
  - #56 にて対応

