### PR TITLE
Fix memberships_controller

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -16,10 +16,10 @@ class MembershipsController < ApplicationController
   def destroy
     @user = User.friendly.find params[:user_id]
     @membership = @user.memberships.find params[:id]
-    if @membership.group.members.length == 1 && @membership.group.projects.length > 0
-      render json: { success: false, message: 'This group still has projects.' }
-    else
+    if @membership.deletable?
       @membership.destroy
+    else
+      render json: { success: false, message: 'You can not leave this group.' }
     end
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -19,7 +19,7 @@ class MembershipsController < ApplicationController
     if @membership.deletable?
       @membership.destroy
     else
-      render json: { success: false, message: 'You can not leave this group.' }
+      render json: { success: false, message: 'You can not remove this member.' }
     end
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -28,4 +28,8 @@ class Membership < ApplicationRecord
       Membership::ROLE[role] == self.role
     end
   end
+
+  def deletable?
+    (role == 'admin' && group.admins.count > 1) || role == 'editor'
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -30,6 +30,6 @@ class Membership < ApplicationRecord
   end
 
   def deletable?
-    (role == 'admin' && group.admins.count > 1) || role == 'editor'
+    (admin? && group.admins.count > 1) || editor?
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -20,7 +20,6 @@ class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :group
 
-  after_create -> { update_attributes role: ROLE[:admin] }, if: -> { group.admins.none? }
   validates :role, presence: true, inclusion: { in: ROLE.values }
 
   Membership::ROLE.keys.each do |role|

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -47,10 +47,10 @@
 
     $(document).on "ajax:success", ".remove-member-btn", (event) ->
       data = event.detail[0]
-      if data.success == false
-        alert data.message
-      else
+      if data.success
         $(this).closest("li").remove()
+      else
+        alert data.message
 
     $(document).on "ajax:success", "#new_member", (event) ->
       $("#members").append event.detail[0].html

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -45,8 +45,12 @@
     $(document).on "change", ".membership-role", (event) ->
       Rails.fire(event.target.form, "submit")
 
-    $(document).on "ajax:success", ".remove-member-btn", () ->
-      $(this).closest("li").remove()
+    $(document).on "ajax:success", ".remove-member-btn", (event) ->
+      data = event.detail[0]
+      if data.success == false
+        alert data.message
+      else
+        $(this).closest("li").remove()
 
     $(document).on "ajax:success", "#new_member", (event) ->
       $("#members").append event.detail[0].html

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -16,4 +16,8 @@
 - content_for :bottom do
   coffee:
     $(document).on "ajax:success", ".leave-btn", () ->
-      $(this).closest("li").remove()
+      data = event.detail[0]
+      if data.success == false
+        alert data.message
+      else
+        $(this).closest("li").remove()

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -15,9 +15,9 @@
 
 - content_for :bottom do
   coffee:
-    $(document).on "ajax:success", ".leave-btn", () ->
+    $(document).on "ajax:success", ".leave-btn", (event) ->
       data = event.detail[0]
-      if data.success == false
-        alert data.message
-      else
+      if data.success
         $(this).closest("li").remove()
+      else
+        alert data.message

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -37,14 +37,34 @@ describe MembershipsController, type: :controller do
   end
 
   describe 'DELETE destroy' do
-    context 'when a user destroyed own membership' do
-      before do
-        sign_in user
-        group = Group.create name: 'foo'
-        membership = user.memberships.create group_id: group.id
-        delete :destroy, params: { user_id: user.id, id: membership.id }, format: :json
+    subject { delete :destroy, params: { user_id: user.id, id: membership.id } }
+
+    let!(:group) { FactoryBot.create(:group)}
+    let!(:membership) { user.memberships.create(group: group) }
+
+    before { sign_in user }
+
+    context 'when 2 group members (admins)' do
+      # Another user's membership
+      before { FactoryBot.create(:membership, group: group, role: 'admin') }
+
+      it 'deletes 1 membership' do
+        expect { subject }.to change { Membership.count }.by(-1)
       end
-      it { is_expected.to render_template :destroy }
+    end
+
+    context 'when 2 group members (admin and editor)' do
+      before { FactoryBot.create(:membership, group: group, role: 'editor') }
+
+      it 'does NOT delete admin membership' do
+        expect { subject }.not_to change { Membership.count }
+      end
+    end
+
+    context 'when 1 group member' do
+      it 'does NOT delete membership' do
+        expect { subject }.not_to change { Membership.count }
+      end
     end
   end
 end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -40,7 +40,7 @@ describe MembershipsController, type: :controller do
     subject { delete :destroy, params: { user_id: user.id, id: membership.id } }
 
     let!(:group) { FactoryBot.create(:group)}
-    let!(:membership) { user.memberships.create(group: group) }
+    let!(:membership) { user.memberships.create(group: group, role: 'admin') }
 
     before { sign_in user }
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -34,7 +34,7 @@ describe ProjectsController, type: :controller do
       end
       describe 'GET new' do
         before do
-          user_project.owner.memberships.create group_id: group_project.owner.id
+          user_project.owner.memberships.create(group_id: group_project.owner.id, role: 'admin')
           sign_in user_project.owner
           get :new
         end
@@ -43,7 +43,7 @@ describe ProjectsController, type: :controller do
       describe 'DELETE destroy' do
         context 'without collaborators' do
           before do
-            user_project.owner.memberships.create group_id: group_project.owner.id
+            user_project.owner.memberships.create(group_id: group_project.owner.id, role: 'admin')
             sign_in user_project.owner
             delete :destroy, params: { owner_name: project.owner.slug, id: project.id }
           end
@@ -53,7 +53,7 @@ describe ProjectsController, type: :controller do
           let(:user) { FactoryBot.create :user }
           let(:group) { FactoryBot.create :group }
           before do
-            user_project.owner.memberships.create group_id: group_project.owner.id
+            user_project.owner.memberships.create(group_id: group_project.owner.id, role: 'admin')
             sign_in user_project.owner
             user.collaborations.create project_id: project
             group.collaborations.create project_id: project
@@ -72,7 +72,7 @@ describe ProjectsController, type: :controller do
       end
       describe 'GET edit' do
         before do
-          user_project.owner.memberships.create group_id: group_project.owner.id
+          user_project.owner.memberships.create(group_id: group_project.owner.id, role: 'admin')
           sign_in user_project.owner
           get :edit, params: { owner_name: project.owner.slug, id: project.id }
         end
@@ -103,7 +103,7 @@ describe ProjectsController, type: :controller do
 
       describe 'GET recipe_cards_list' do
         before do
-          user_project.owner.memberships.create group_id: group_project.owner
+          user_project.owner.memberships.create(group_id: group_project.owner, role: 'admin')
           sign_in user_project.owner
           get :recipe_cards_list, params: { owner_name: project.owner, project_id: project }, xhr: true
         end
@@ -116,7 +116,7 @@ describe ProjectsController, type: :controller do
         let(:params) { { owner_name: project.owner, id: project.id, project: project_params } }
 
         before do
-          user_project.owner.memberships.create group_id: group_project.owner.id
+          user_project.owner.memberships.create(group_id: group_project.owner.id, role: 'admin')
           sign_in user_project.owner
         end
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,10 +1,41 @@
 # frozen_string_literal: true
 
 describe Membership do
-  let(:membership) { FactoryBot.build :membership }
   describe '#admin?' do
-    before { membership.role = Membership::ROLE[:admin] }
     subject { membership.admin? }
+    let(:membership) { FactoryBot.create(:membership, role: 'admin') }
     it { is_expected.to be true }
+  end
+
+  describe '#editor?' do
+    subject { membership.editor? }
+    group = FactoryBot.create(:group)
+    let(:membership) { FactoryBot.create(:membership, role: 'editor', group: group) }
+    # 最低でも１人はadminが必要なので作成
+    before { FactoryBot.create(:membership, role: 'admin', group: group) }
+    it { is_expected.to eq true }
+  end
+
+  describe '#deletable?' do
+    subject { membership.deletable? }
+
+    context 'when 1 admin' do
+      let(:membership) { FactoryBot.create(:membership, role: 'admin') }
+      it { is_expected.to eq false }
+    end
+
+    context 'when 2 admins' do
+      let(:memberships) { FactoryBot.create_list(:membership, 2, role: 'admin', group: FactoryBot.create(:group)) }
+      let(:membership) { memberships.first }
+      it { is_expected.to eq true }
+    end
+
+    context 'when role is editor' do
+      group = FactoryBot.create(:group)
+      let(:membership) { FactoryBot.create(:membership, role: 'editor', group: group) }
+
+      before { FactoryBot.create(:membership, role: 'admin', group: group) }
+      it { is_expected.to eq true }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -174,14 +174,6 @@ describe User do
         expect(user.is_editor_of?(group_membered)).to be true
       end
     end
-
-    context 'グループにadminが存在していない場合' do
-      before { FactoryBot.create(:membership, group: group_membered, user: user, role: Membership::ROLE[:editor]) }
-      it "role: 'admin'として登録されること" do
-        expect(user.is_admin_of?(group_membered)).to be true
-        expect(user.is_editor_of?(group_membered)).to be false
-      end
-    end
   end
 
   describe '#membership_in(group)' do


### PR DESCRIPTION
#55 に関連した作業を分割した

membershipの削除について

adminの時
- 他にもadminが最低一人いる必要がある

editorの時
- 削除できる

変更前は@membership.group.projects.length > 0 でプロジェクトの有無を確認していたが、
それはGroupsControllerの責務であるので削除

- [x] Group#membersにMembership#roleがadminなUserが最低一人いるようにする
  - 自分以外に`admin` がいるならば、自分のメンバーシップを削除できる

## WIP
自分のメンバーシップを削除するのは`groups/` でできるようだが
![image](https://user-images.githubusercontent.com/5820754/45103786-a5700880-b16b-11e8-8e21-9bef87237b54.png)

以下のようになるが、グループとのメンバーシップが残っている場合、変わらず編集画面にアクセスできる

![image](https://user-images.githubusercontent.com/5820754/45103836-ba4c9c00-b16b-11e8-8e88-d189dd3a1afb.png)

☝️  削除できなかった場合、エラーメッセージを出すようにした

- いっそのこと`groups/` は削除するか？ (Groupを削除した場合の遷移先を考える必要があるが、それは #55 )
- 自分がadminの場合、メンバーシップを削除する操作はない 👇 これはどうするか？

![image](https://user-images.githubusercontent.com/5820754/45104302-c5ec9280-b16c-11e8-9404-7c4f06af1509.png)
