### PR TITLE
Fix bug on clearing the value of selection

### DIFF
--- a/app/assets/javascripts/add_group_member.js
+++ b/app/assets/javascripts/add_group_member.js
@@ -22,8 +22,3 @@ $(() =>
       }
       }
   }));
-
-window.clearSelect2Value = function() {
-  $("#s2id_member").select2("val", "");
-  $("input#membership_user_id").val("");
-};

--- a/app/assets/javascripts/basic_informations.js
+++ b/app/assets/javascripts/basic_informations.js
@@ -152,8 +152,3 @@ window.showLink = function(d) {
 };
 
 window.children = d => d["children"];
-
-window.clearSelect2Value = function() {
-  $("#s2id_user_name").select2("val","");
-  $("input#user_name").val("");
-};

--- a/app/assets/javascripts/collaborator.js
+++ b/app/assets/javascripts/collaborator.js
@@ -1,7 +1,7 @@
 $(function() {
   $(document).on("ajax:success", "#new_collaboration", function(event) {
     $("#collaborations").append(event.detail[0].html);
-    clearSelect2Value();
+    $("#collaborator_name").val(null).trigger("change");
   });
 
   $(document).on("ajax:success", ".remove-collaboration-btn", function() {

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -50,4 +50,4 @@
 
     $(document).on "ajax:success", "#new_member", (event) ->
       $("#members").append event.detail[0].html
-      clearSelect2Value()
+      $("#member_name").val(null).trigger("change");


### PR DESCRIPTION
`select2` を使用したユーザーの追加画面にて、追加した後も値が残っているために、2度追加できる状態だった

グループ編集画面、「Add Member」
![2018-09-06 23 44 29](https://user-images.githubusercontent.com/5820754/45167740-bafd3500-b234-11e8-8769-59aee6566fda.png)

プロジェクト詳細画面上部、「Project Owners & Collaborators」
![add-collaborators-before](https://user-images.githubusercontent.com/5820754/45167746-bd5f8f00-b234-11e8-9aed-2252abe70b77.png)

## 修正内容
追加した後に値をクリアするようにした

参考：
https://select2.org/programmatic-control/add-select-clear-items#clearing-selections
