### PR TITLE
Collaboratorの画像を丸くする

### DIFF
--- a/app/views/collaborations/_collaboration.html.slim
+++ b/app/views/collaborations/_collaboration.html.slim
@@ -1,6 +1,6 @@
 li.collaboration
   span.avatar
-    = image_tag collaboration.owner.avatar.thumb.url
+    = image_tag collaboration.owner.avatar.thumb.url, width: 40, height: 40, class: "rounded-circle"
   span.name
     = collaboration.owner.name
   - if can? :manage, collaboration


### PR DESCRIPTION
modalにおけるcollaboratorの画像を丸くし、サイズもownerのものと合わせた
## before
![2018-09-14 21 53 22](https://user-images.githubusercontent.com/5820754/45551507-25cbf300-b869-11e8-951a-9e142596fa07.png)

## after
![2018-09-14 21 54 09](https://user-images.githubusercontent.com/5820754/45551526-30868800-b869-11e8-8671-cffe67fd7bac.png)

