### PR TITLE
Fix ogp properties

### DIFF
--- a/app/views/components/_base_ogp.html.slim
+++ b/app/views/components/_base_ogp.html.slim
@@ -1,10 +1,12 @@
 meta property="og:site_name" content="Fabble"
-meta property="og:email" content="support@fabble.cc"
 meta property="og:type" content="article"
 meta property="og:url" content="#{request.url}"
 meta property="og:title" content="#{local_assigns[:model]&.ogp_title || 'Fabble'}"
 meta property="og:description" content="#{local_assigns[:model]&.ogp_description.presence || 'New Platform to Share Fab Projects all over the world'}"
 meta property="og:image" content="#{local_assigns[:model]&.ogp_image(request.base_url) || asset_url('/images/logo.png')}"
+meta property="og:image:width" content="400"
+meta property="og:image:height" content="300"
+meta property="fb:app_id" content="1749131181871409"
 
 - ogp_video = local_assigns[:model]&.ogp_video.presence
 - if ogp_video


### PR DESCRIPTION
- image:width, heightを指定した
- og:emailの削除
  - og:typeがbusiness.businessでないと、business:contact_data:emailを使用できない
https://developers.facebook.com/docs/reference/opengraph/object-type/business.business/ (business:contanct_dataの項参照)

- fb:app_idの指定

## Twitter Card Validator
![2018-10-30 17 48 58](https://user-images.githubusercontent.com/5820754/47706881-b0c44980-dc6d-11e8-9e1f-677f7ed754a8.png)

## Facebook Sharing Debugger
![2018-10-30 17 38 08](https://user-images.githubusercontent.com/5820754/47706955-dbae9d80-dc6d-11e8-96b6-89c42ce5ef63.png)

修正前の警告
![2018-10-30 17 24 57](https://user-images.githubusercontent.com/5820754/47707098-45c74280-dc6e-11e8-9131-6f53c50096b7.png)

