### PR TITLE
use send_file instead of send_data

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -98,7 +98,7 @@ class UsersController < ApplicationController
     user = User.active.find_by(name: params[:user_id])
     if can?(:download_backup, user)
       backup = Backup.new(user)
-      send_data(backup.zip_path.read, filename: backup.zip_filename)
+      send_file(backup.zip_path, filename: backup.zip_filename)
     else
       render_403
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -253,7 +253,7 @@ describe UsersController, type: :controller do
     end
 
     it do
-      expect(@controller).to receive(:send_data).with(backup.zip_path.read, filename: backup.zip_filename) { @controller.render nothing: true }
+      expect(@controller).to receive(:send_file).with(backup.zip_path, filename: backup.zip_filename) { @controller.render nothing: true }
       subject
     end
 


### PR DESCRIPTION
 `send_data` では全て読み込んでから返すのでメモリを使う。
動的に作ったバイナリを返すときやさほど大きくないファイルを扱うときは `send_data` を使うが、対象となるファイルが大きくなる可能性がある＆ファイルシステム上に存在する場合は、 `send_file` を使う。

https://api.rubyonrails.org/classes/ActionController/DataStreaming.html#method-i-send_file

ステージング/本番でうまくいかないときは `config.action_dispatch.x_sendfile_header` を変更する必要がある。


