### PR TITLE
ダウンロード対象のZIPファイルが存在しなかった場合にエラー中断しないようにする

### DIFF
--- a/app/services/backup.rb
+++ b/app/services/backup.rb
@@ -240,6 +240,10 @@ class Backup
       end
       contents.compact!
 
+      # ゴミデータなどでファイルが存在しない場合があり、
+      # その場合 FileUtils.copy が例外を投げるので、存在するファイルにしぼる
+      contents.select! { |path| FileTest.file?(path) }
+
       if contents.present?
         contents_dir = json_output_dir.join('projects', 'media', project.name)
         contents_dir.mkpath


### PR DESCRIPTION
ダウンロード用ZIPファイルを作成する際に、何らかの理由で対象のファイルが見つからなかったとき、エラー終了して通知されないので、これを回避し、実際にダウンロードが可能なファイルのみを含めるようにする。

`FileUtils.copy` はコピー元が存在しないとき `Errno::ENOENT` を送出
