### PR TITLE
閲覧権限のないprivate projectへのアクセスを404にする

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,7 +18,11 @@ class ProjectsController < ApplicationController
   def show
     @project = @owner.projects.active.includes(usages: [:attachments, :figures, :contributions, :project])
                      .friendly.find(params[:id])
-    authorize!(:read, @project)
+
+    unless can?(:read, @project)
+      render_404
+      return
+    end
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
これまでは以下のコードで401にしていたが、アクセスしたURLが存在することもわからないようにする

https://github.com/takeyuwebinc/gitfab2/blob/887a9b11da85648dc1e7436a9424fe11b9b77629/app/controllers/application_controller.rb#L9