### PR TITLE
Facebookログインの有効/無効を切り替え可能に

### DIFF
--- a/app/views/sessions/index.html.slim
+++ b/app/views/sessions/index.html.slim
@@ -24,7 +24,8 @@
     - if ENV["GOOGLE_APP_ID"]
       li.form-group
         = link_to_google_sign_in
-    li.form-group
-      = link_to_facebook_sign_in
+    - if ENV["FACEBOOK_APP_ID"]
+      li.form-group
+        = link_to_facebook_sign_in
     li.form-group
       = link_to "Sign up with Password", new_user_path, class: "btn"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -40,11 +40,12 @@
             .btn.disabled Already signed in to Google
           - else
             = link_to_google_sign_in
-      li.form-group
-        - if current_user.connected_with_facebook?
-          .btn.disabled Already signed in to Facebook
-        - else
-          = link_to_facebook_sign_in
+      - if ENV["FACEBOOK_APP_ID"]
+        li.form-group
+          - if current_user.connected_with_facebook?
+            .btn.disabled Already signed in to Facebook
+          - else
+            = link_to_facebook_sign_in
 
   .panel
     h1 バックアップ


### PR DESCRIPTION
Close #97 

ENV["FACEBOOK_APP_ID"]の有無によりサインインボタンの表示・非表示を切り替え

## 確認方法
`.envrc` から `FACEBOOK_APP_ID` を一時的に削除 (一応`FACEBOOK_APP_SECRET` も削除)

```sh
$ direnv allow
direnv: loading .envrc
direnv: export +COMPOSE_FILE +GITHUB_APP_ID +GITHUB_APP_SECRET +GOOGLE_APP_ID +GOOGLE_APP_SECRET
```

その後、`rails s`

## 確認してほしいこと
- [x] ログイン画面にて`Sign in with Facebook` ボタンが表示されないこと
- [x] ユーザープロフィール編集画面、アカウント連携にて`Sign in with Facebook` ボタンが表示されないこと
- [x] `FACEBOOK_APP_ID` のみを対象としたがそれでいいかどうか
