### PR TITLE
アクセス数データ投入タスク

### DIFF
--- a/app/models/project_access_log.rb
+++ b/app/models/project_access_log.rb
@@ -23,6 +23,8 @@ class ProjectAccessLog < ApplicationRecord
   belongs_to :project, counter_cache: :project_access_logs_count
   belongs_to :user, optional: true
 
+  ONE_MONTH = 30
+
   def self.log!(project, user, created_on = Date.current)
     if user
       # プロジェクト管理者の場合はログしない
@@ -33,5 +35,20 @@ class ProjectAccessLog < ApplicationRecord
     end
 
     create!(project: project, user: user)
+  end
+
+  def self.log_last_days!(project, total, days: ONE_MONTH)
+    if total < days
+      total.downto(1) do |i|
+        create!(project: project, created_at: DateTime.current - i.day)
+      end
+    else
+      count_per_day = (total / days).round
+      days.downto(1) do |i|
+        count_per_day.times do
+          create!(project: project, created_at: DateTime.current - i.day)
+        end
+      end
+    end
   end
 end

--- a/lib/tasks/project_access_log.rake
+++ b/lib/tasks/project_access_log.rake
@@ -1,0 +1,30 @@
+require 'csv'
+
+namespace :project_access_log do
+  desc 'Create access log from csv'
+  task :log_from_csv, [:csv_path, :days] => :environment do |_task, args|
+    args.with_defaults(days: '30')
+    # CSV ファイルからアクセスログを作成する
+    # CSVの形式： /オーナー名/プロジェクト名,アクセス数
+    # 例： /takeyuweb/tutorial-1,3
+    ::CSV.foreach(args[:csv_path]).with_index(1) do |row, line|
+      next if row.blank?
+
+      owner_name, project_name = row[0].split('/').reject(&:empty?)
+
+      # どちらかがない場合、データ不備とみなす
+      if owner_name.nil? || project_name.nil?
+        puts "line#{line}: #{row[0]} is not found"
+        next
+      end
+
+      project = Project.active.find_by(slug: project_name, owner: Owner.find_by(owner_name))
+
+      if project
+        ProjectAccessLog.log_last_days!(project, row[1].to_i, days: args[:days].to_i)
+      else
+        puts "line#{line}: #{row[0]} is not found"
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/project_access_log_spec.rb
+++ b/spec/lib/tasks/project_access_log_spec.rb
@@ -1,0 +1,35 @@
+require 'rake'
+
+describe 'project_access_log' do
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require('project_access_log', ["#{Rails.root}/lib/tasks"])
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'project_access_log:log_from_csv' do
+    subject { @rake['project_access_log:log_from_csv'].invoke(csv_path) }
+    let(:csv_path) { Rails.root.join('tmp', 'log_csv_test.csv') }
+
+    before do
+      FactoryBot.create(:user_project, name: 'hoge',owner: FactoryBot.create(:user, name: 'owner1'))
+      FactoryBot.create(:user_project, name: 'hoge',owner: FactoryBot.create(:user, name: 'owner2'))
+      rows = <<~ROWS
+          /owner1/hoge,2
+          /owner2/hoge,2
+          /owner3,2
+
+      ROWS
+
+      File.write(csv_path, rows, mode: 'w')
+      @rake['project_access_log:log_from_csv'].reenable
+    end
+
+    after { FileUtils.rm(csv_path, force: true) }
+
+    it do
+      expect{ subject }.to change{ ProjectAccessLog.count }.from(0).to(4)
+    end
+  end
+end

--- a/spec/models/project_access_log_spec.rb
+++ b/spec/models/project_access_log_spec.rb
@@ -60,4 +60,52 @@ RSpec.describe ProjectAccessLog, type: :model do
       end
     end
   end
+
+  describe '.log_last_days!' do
+    subject { ProjectAccessLog.log_last_days!(project, total, days: 30) }
+    let(:project) { FactoryBot.create(:user_project) }
+
+    context 'total < 30' do
+      # total日分作成、1日あたり1つのログを作成
+      let(:total) { 29 }
+
+      it do
+        expect{ subject }.to change{ ProjectAccessLog.count }.from(0).to(29)
+      end
+
+      specify '一番古いログが29日前に作成されていること' do
+        subject
+        oldest_log = ProjectAccessLog.first
+        expect(oldest_log.created_at.to_date).to eq 29.days.ago.to_date
+      end
+    end
+
+    context 'total == 30' do
+      # 30日分作成、1日あたりtotalを30で割った数(四捨五入)でログを作成
+      let(:total) { 30 }
+      it 'creates 30 logs' do
+        expect{ subject }.to change{ ProjectAccessLog.count }.from(0).to(30)
+      end
+
+      specify '一番古いログが30日前に作成されていること' do
+        subject
+        oldest_log = ProjectAccessLog.first
+        expect(oldest_log.created_at.to_date).to eq 30.days.ago.to_date
+      end
+    end
+
+    context 'total == 59' do
+      # 30日分作成、1日あたりtotalを30で割った数(四捨五入)でログを作成
+      let(:total) { 59 }
+      it 'creates 60 logs' do
+        expect{ subject }.to change{ ProjectAccessLog.count }.from(0).to(60)
+      end
+
+      specify '一番古いログが30日前に作成されていること' do
+        subject
+        oldest_log = ProjectAccessLog.first
+        expect(oldest_log.created_at.to_date).to eq 30.days.ago.to_date
+      end
+    end
+  end
 end


### PR DESCRIPTION
Close #95 

３０日分に均等に分ける
- 日数で割った数を四捨五入
  - 59 / 30 なら1.9666 ということで（1日あたり）2にする
- アクセス数が30より少ない場合
  - 1日1アクセスとしてアクセス数と同じ日数分作成（29なら29日分）
  - なるべく均等にする、ということでそうしました

## 実行方法

```sh
# 第２引数はデフォルトで30（日間）、引数なしで実行する場合
./bin/rake project_access_log:log_from_csv['./tmp/fabble_page_vier_last_1m.csv']
```

not found メッセージ
```sh
line2: /tender-dynamiclabo/makita-battery-adapter is not found
line12: /3-d-a-l/3dfilament-join is not found
line27: /daisukekobayashi-lif-iey/inkscape-lasercutter is not found
# ...
```

## その他
提供されたCSVファイルでは例えば`/takeyuweb,2` のように`オーナー名/プロジェクト名` の2つが揃っていないものが見受けられました
それはデータ不備として not found としています
