### PR TITLE
Fix changing the order of annotations

### DIFF
--- a/app/assets/javascripts/card_order.js
+++ b/app/assets/javascripts/card_order.js
@@ -82,8 +82,8 @@ $(function() {
           positionForm.val(position);
           idForm = annotation_field.find(".id");
           idForm.val(id);
-          state.find(".submit-annotation-order").click();
         }
+        state.find(".submit-annotation-order").click();
       }
     }
 


### PR DESCRIPTION
ref #101 (自動クローズにはしてないです)

> Annotation の並べ替え操作を２回つづけてから保存したとき、２回目の操作が反映されない

これについては解消できています

---

`annotations_attributes` が１つ分しか送られていなかった

```sh
Processing by StatesController#update as JS
  Parameters: {"utf8"=>"✓", "state"=>{"annotations_attributes"=>{"1557278918839"=>{"position"=>"1", "id"=>"29745"}}}, "commit"=>"submit", "owner_name"=>"noriyotcptest01", "project_id"=>"project01-1", "id"=>"29742"}
```

以下のように並べ替え後のAnnotations のid, position を全部の分送ることにした

```sh
Processing by StatesController#update as JS
  Parameters: {"utf8"=>"✓", "state"=>{"annotations_attributes"=>{"1557282311715"=>{"position"=>"1", "id"=>"29745"}, "1557282311717"=>{"position"=>"2", "id"=>"29743"}, "1557282311719"=>{"position"=>"3", "id"=>"29744"}}}, "commit"=>"submit", "owner_name"=>"noriyotcptest01", "project_id"=>"project01-1", "id"=>"29742"}
```

---

> State の並べ替えがうまくいくときといかないときがある
> Annotation の並び替えがうまくいくときいかないときがある

@takeyuweb  この２つについては、特定の再現方法もないということでしょうか？ こちらでも引き続き調査は続けますが・・・
