### PR TITLE
タグにハッシュタグがついている場合でも検索できるようにした

### DIFF
--- a/app/views/projects/_tags.html.slim
+++ b/app/views/projects/_tags.html.slim
@@ -2,7 +2,7 @@
   - if project.tags.any?
     - project.tags.each do |tag|
       span.tag
-        = link_to tag.name, "#{search_path}?q=#{tag.name}"
+        = link_to tag.name, search_path(q: tag.name)
   - else
     span
       'no tags

--- a/app/views/projects/_tags_and_keywords.html.slim
+++ b/app/views/projects/_tags_and_keywords.html.slim
@@ -7,7 +7,7 @@
         .tags.selected-tags
           - selected_tags.each do |tag_name|
             .tag
-              = link_to tag_name, "/search?q=#{tag_name}"
+              = link_to tag_name, search_path(q: tag_name)
 
           .show-all.btn
             'Show All Tags
@@ -15,7 +15,7 @@
         .tags.all-tags
           - all_tags.each do |tag_name|
             .tag
-              = link_to tag_name, "/search?q=#{tag_name}"
+              = link_to tag_name, search_path(q: tag_name)
 
           .show-selected.btn
             'Show Selected Tags

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -1,4 +1,4 @@
 li.tag
-  = link_to tag.name, "#{search_path}?q=#{tag.name}"
+  = link_to tag.name, search_path(q: tag.name)
   - if can?(:destroy, tag)
     = link_to "", tag_path(tag), method: :delete, remote: true, class: "delete-tag"


### PR DESCRIPTION
Fix #103 

タグが `#` から始まっている場合(例：#fabcon) でも検索されるようにした

path helper に変更して、リンクパラメータに付く検索語句をエスケープする

ハッシュタグを削除した場合(例：fabcon) なら部分一致で検索されるのは従来通り

検索結果画面でのURL
![image](https://user-images.githubusercontent.com/5820754/63068208-4145ef00-bf4d-11e9-86b6-b5b5d375e7b7.png)


## 修正したview について

`app/views/projects/_tags_and_keywords.html.slim`
レンダリングされているページ
- `app/views/projects/index.html.slim` （トップページ）
- `app/views/projects/search.html.slim` （検索結果のページ）

---

`app/views/tags/_tag.html.slim`
- `app/views/projects/_basic_informations.html.slim`
プロジェクトの詳細ページとMemoのページ

![image](https://user-images.githubusercontent.com/5820754/63008705-13659980-bebe-11e9-95b8-ac3a0af58c28.png)

---

`app/views/projects/_tags.html.slim`
このパーシャルがどこでレンダリングされているかわかりませんでした。一応同様の修正をしておきましたが・・・もしかして：使われてない
