### PR TITLE
Fix ProjectAccessLog#log! and its spec

### DIFF
--- a/app/models/project_access_log.rb
+++ b/app/models/project_access_log.rb
@@ -25,13 +25,13 @@ class ProjectAccessLog < ApplicationRecord
 
   ONE_MONTH = 30
 
-  def self.log!(project, user, created_on = Date.current)
+  def self.log!(project, user)
     if user
       # プロジェクト管理者の場合はログしない
       return if user.is_project_manager?(project)
 
       # ログは1ユーザーにつき1プロジェクト1日1回
-      return if where(user: user, project: project).where("DATE(created_at) = ?", created_on).exists?
+      return if where(user: user, project: project).where(created_at: DateTime.current.all_day).exists?
     end
 
     create!(project: project, user: user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ControllerMacros::InstanceMethods, :type => :controller
   config.include ActiveJob::TestHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:suite) do
     DatabaseRewinder.clean_all


### PR DESCRIPTION
テストが落ちてしまっていたので修正しました

https://travis-ci.org/takeyuwebinc/gitfab2/jobs/572837144

---

Remove third argument
仕様上ではログは1ユーザーにつき1プロジェクト1日1回

もともと Date オブジェクトを渡せるようにしていたが、それは検索で使用されるだけである
例えば、次の日から内容の同じログを検索しても見つからないので新たに作成するが、本日の日付で作成してしまう
つまり（テスト上で）同じ日付のログが複数作成されてしまう可能性が出てくる

本日に作成されたログだけを対象に検索することにした
https://easyramble.com/get-today-record-with-rails-activerecord.html

タイムゾーンは config.time_zone = 'Tokyo'