### PR TITLE
お気に入りが動作しなかった不具合を修正

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,4 +1,10 @@
 class LikesController < ApplicationController
+  def show
+    project = Project.find_with(params[:owner_name], params[:project_id])
+    liked = project.likes.where(user: current_user).exists?
+    render json: { success: true, like: { liked: liked } }
+  end
+
   def create
     project = Project.find_with(params[:owner_name], params[:project_id])
     like = Like.find_or_initialize_by(project: project, user: current_user)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,13 +23,8 @@ class ProjectsController < ApplicationController
       return
     end
 
-    respond_to do |format|
-      format.html do
-        ProjectAccessLog.log!(@project, current_user)
-        @project_comments = @project.project_comments.order(:id)
-      end
-      format.json
-    end
+    ProjectAccessLog.log!(@project, current_user)
+    @project_comments = @project.project_comments.order(:id)
   end
 
   def new

--- a/app/frontend/like.ts
+++ b/app/frontend/like.ts
@@ -5,13 +5,13 @@ import setupCSRFToken from "./lib/setupCSRFToken";
 interface State {
   clickEnabled: boolean;
   liked: boolean;
-  updateLikeUrl: string;
+  likeUrl: string;
   visible: boolean;
 }
 const State: State = {
   clickEnabled: true,
   liked: false,
-  updateLikeUrl: "",
+  likeUrl: "",
   visible: true
 };
 
@@ -25,12 +25,12 @@ interface Actions {
 }
 const Actions: ActionsType<State, Actions> = {
   enable: (clickEnabled: boolean) => () => ({ clickEnabled }),
-  initState: ({ liked, updateLikeUrl }) => () => ({ liked, updateLikeUrl }),
+  initState: ({ liked }) => () => ({ liked }),
   like: () => async (state, actions) => {
     actions.setIcon(true);
 
     try {
-      const response = await axios.post(state.updateLikeUrl);
+      const response = await axios.post(state.likeUrl);
       if (!response.data.success) {
         actions.setIcon(false);
       }
@@ -45,7 +45,7 @@ const Actions: ActionsType<State, Actions> = {
     actions.setIcon(false);
 
     try {
-      await axios.delete(state.updateLikeUrl);
+      await axios.delete(state.likeUrl);
     } catch {
       alertError();
       actions.setIcon(true);
@@ -72,10 +72,14 @@ const View: View<State, Actions> = (state, actions) =>
     oncreate: () => {
       setupCSRFToken();
       axios
-        .get(`${window.location.pathname}.json`)
+        .get(state.likeUrl)
         .then(response => actions.initState(response.data.like))
         .catch(actions.makeInvisible);
     }
   });
 
-app(State, Actions, View, document.querySelector("#like-component"));
+const container = document.querySelector<HTMLDivElement>("#like-component");
+if (container) {
+  State.likeUrl = String(container.dataset.likeUrl);
+  app(State, Actions, View, container);
+}

--- a/app/views/projects/_basic_informations.html.slim
+++ b/app/views/projects/_basic_informations.html.slim
@@ -37,7 +37,7 @@ section#basic-informations
             = link_to "Add Tag", "#", class: "btn", id: "show-tag-form"
 
       .right style="text-align: right"
-        #like-component
+        #like-component data-like-url="#{project_likes_path(@project.owner, @project, format: :json)}"
         = javascript_webpack_tag "like"
 
   section.body

--- a/app/views/projects/show.json.jb
+++ b/app/views/projects/show.json.jb
@@ -1,6 +1,0 @@
-{
-  like: {
-    liked: Like.exists?(user: current_user, project: @project),
-    updateLikeUrl: project_likes_path(@project.owner, @project, format: :json)
-  }
-}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
   resources :projects, path: '/:owner_name', except: [:index, :new, :create, :search] do
     delete 'destroy_or_render_edit', to: 'projects#destroy_or_render_edit'
     resources :collaborations, only: :create
-    resource :likes, only: [:create, :destroy]
+    resource :likes, only: [:show, :create, :destroy]
     resources :note_cards
     resources :states, except: :index do
       resources :annotations, except: :index do

--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -1,5 +1,28 @@
 RSpec.describe LikesController, type: :controller do
 
+  describe "GET #show" do
+    let(:project) { FactoryBot.create(:project) }
+    let(:user) { FactoryBot.create(:user) }
+
+    before { sign_in(user) }
+  
+    context "when liked project" do
+      before { Like.create!(project: project, user: user) }
+
+      it "returns liked" do
+        get :show, params: { owner_name: project.owner, project_id: project }
+        expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true, like: { liked: true } })
+      end
+    end
+
+    context "when not liked project" do
+      it "likes a project" do
+        get :show, params: { owner_name: project.owner, project_id: project }
+        expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true, like: { liked: false } })
+      end
+    end
+  end
+
   describe "POST #create" do
     subject { post :create, params: { owner_name: project.owner, project_id: project } }
     let(:project) { FactoryBot.create(:project) }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -23,18 +23,8 @@ describe ProjectsController, type: :controller do
     let(:project) { send "#{owner_type}_project" }
     context "with a project owned by a #{owner_type}" do
       describe 'GET show' do
-        subject { get :show, params: { owner_name: project.owner.slug, id: project.name, format: format } }
-        let(:format) { "html" }
-
-        context "on format html" do
-          let(:format) { "html" }
-          it { is_expected.to render_template :show }
-        end
-
-        context "on format json" do
-          let(:format) { "json" }
-          it { is_expected.to render_template :show }
-        end
+        subject { get :show, params: { owner_name: project.owner.slug, id: project.name } }
+        it { is_expected.to render_template :show }
 
         context "when project is private" do
           let(:is_private) { true }


### PR DESCRIPTION
プロジェクトページトップ以外でお気に入り☆が正しく動作していなかった。
また、不要なAPIリクエストを抑制した。

![お気に入り](https://user-images.githubusercontent.com/60980/89872958-aa118700-dbf4-11ea-9d4c-a2237d63bbc0.gif)
