### PR TITLE
RMagick関係の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'uglifier'
 gem 'sprockets', '3.7.2'
 
 gem 'stl', github: 'oshimaryo/stl-ruby'
-gem 'stl2gif', github: 'oshimaryo/stl2gif', branch: 'develop', ref: '2e508559aa3e2e5f935214d2e6988f1862cea26f'
+gem 'stl2gif', github: 'takeyuwebinc/stl2gif', branch: 'develop'
 gem 'mathn' # Used in geometry gem in stl gem
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,8 @@ GIT
       geometry
 
 GIT
-  remote: https://github.com/oshimaryo/stl2gif.git
-  revision: 2e508559aa3e2e5f935214d2e6988f1862cea26f
-  ref: 2e508559aa3e2e5f935214d2e6988f1862cea26f
+  remote: https://github.com/takeyuwebinc/stl2gif.git
+  revision: df7f91e4b3b12e2e0c6c27807f4ccec47ab31003
   branch: develop
   specs:
     stl2gif (0.0.2)
@@ -237,7 +236,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mustache (1.1.0)
+    mustache (1.1.1)
     mysql2 (0.5.2)
     nested_form (0.3.2)
     net-scp (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rmagick (4.0.0)
+    rmagick (4.1.2)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)


### PR DESCRIPTION
- 最新（4.1）にする
- `[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead` への対処