### PR TITLE
アクセス数集計をバッチ化

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,7 +9,7 @@ class ProjectsController < ApplicationController
 
   def index
     projects = Project.published.includes(:figures, :owner)
-    @popular_projects = projects.access_ranking
+    @popular_projects = ProjectAccessStatistic.access_ranking.merge(projects).limit(10)
     @featured_groups = Group.access_ranking
     @recent_projects = projects.order(updated_at: :desc).limit(12)
   end

--- a/app/models/black_list.rb
+++ b/app/models/black_list.rb
@@ -2,12 +2,12 @@
 #
 # Table name: black_lists
 #
-#  id                          :bigint(8)        not null, primary key
-#  reason(理由)                  :text(65535)      not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                                         :bigint(8)        not null, primary key
+#  reason(理由)                               :text(65535)      not null
+#  created_at                                 :datetime         not null
+#  updated_at                                 :datetime         not null
 #  project_id(ブラックリスト対象プロジェクト) :integer          not null
-#  user_id(登録した管理者)            :integer          not null
+#  user_id(登録した管理者)                    :integer          not null
 #
 # Indexes
 #

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -35,11 +35,11 @@ class Group < ApplicationRecord
 
   scope :active, -> { where(is_deleted: false) }
 
-  scope :access_ranking, -> (since: 1.month.ago, limit: 3) do
+  scope :access_ranking, -> (from: 1.month.ago, to: Time.current, limit: 3) do
     Project
       .published
       .joins(:project_access_logs)
-      .where("project_access_logs.created_at > ?", since)
+      .where("project_access_logs.created_at BETWEEN :from AND :to", from: from, to: to)
       .exclude_blacklisted
       .group(:owner_id)
       .order(Arel.sql("COUNT(projects.owner_id) DESC"))

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,6 +50,7 @@ class Project < ApplicationRecord
   has_many :usages, class_name: 'Card::Usage', dependent: :destroy
   has_many :project_comments, dependent: :destroy
   has_many :project_access_logs, dependent: :destroy
+  has_many :project_access_statistics, dependent: :destroy
 
   enum license: { 'by' => 0, 'by-sa' => 1, 'by-nc' => 2, 'by-nc-sa' => 3 }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -184,10 +184,6 @@ class Project < ApplicationRecord
     end
   end
 
-  def self.take_statistics!
-
-  end
-
   private
 
     def generate_draft

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -82,13 +82,14 @@ class Project < ApplicationRecord
     projects
   end
 
-  scope :access_ranking, -> (since: 1.month.ago, limit: 10) do
+  scope :access_ranking, -> (from: 1.month.ago, to: Time.current, limit: 10) do
     published
       .joins(:project_access_logs)
-      .where("project_access_logs.created_at > ?", since)
+      .where("project_access_logs.created_at BETWEEN :from AND :to", from: from, to: to)
       .exclude_blacklisted
       .group(:id)
-      .order(Arel.sql("COUNT(projects.id) DESC"))
+      .select('projects.*, COUNT(projects.id) as access_count')
+      .order(Arel.sql("access_count DESC"))
       .limit(limit)
   end
 
@@ -180,6 +181,10 @@ class Project < ApplicationRecord
        figures_attributes: Figure.updatable_columns
       ]
     end
+  end
+
+  def self.take_statistics!
+
   end
 
   private

--- a/app/models/project_access_statistic.rb
+++ b/app/models/project_access_statistic.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: project_access_statistics
+#
+#  id           :bigint(8)        not null, primary key
+#  access_count :integer          default(0), not null
+#  date_on      :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  project_id   :integer          not null
+#
+# Indexes
+#
+#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id)
+#  index_project_access_statistics_on_project_id              (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#
+
+class ProjectAccessStatistic < ApplicationRecord
+  belongs_to :project
+end

--- a/app/models/project_access_statistic.rb
+++ b/app/models/project_access_statistic.rb
@@ -11,7 +11,7 @@
 #
 # Indexes
 #
-#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id)
+#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id) UNIQUE
 #  index_project_access_statistics_on_project_id              (project_id)
 #
 # Foreign Keys
@@ -21,4 +21,8 @@
 
 class ProjectAccessStatistic < ApplicationRecord
   belongs_to :project
+
+  def self.access_ranking(from: 1.month.ago.to_date, to: Time.current.to_date)
+    Project.joins(:project_access_statistics).group(:project_id).where(project_access_statistics: { date_on: from .. to }).select("projects.*, SUM(project_access_statistics.access_count) AS access_count").order(Arel.sql("access_count DESC"))
+  end
 end

--- a/app/services/take_statistics_service.rb
+++ b/app/services/take_statistics_service.rb
@@ -1,0 +1,22 @@
+require 'singleton'
+
+class TakeStatisticsService
+  include Singleton
+
+  def self.call(date_on)
+    instance.call(date_on)
+  end
+
+  def call(date_on)
+    raise ArgumentError unless date_on.is_a?(Date)
+
+    from = date_on.midnight
+    to = date_on.end_of_day
+    now = Time.current
+  
+    statistics = Project.access_ranking(from: from, to: to, limit: Project.count).map do |project|
+      ProjectAccessStatistic.new(project: project, date_on: date_on, access_count: project.access_count)
+    end
+    ProjectAccessStatistic.import(statistics)
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,3 +2,7 @@
 every 1.day, at: ['20:00'] do
   rake "backup:delete"
 end
+
+every 1.day, at: ['00:30'] do
+  rake 'statistic:daily'
+end

--- a/db/migrate/20200819134327_create_project_access_statistics.rb
+++ b/db/migrate/20200819134327_create_project_access_statistics.rb
@@ -1,0 +1,13 @@
+class CreateProjectAccessStatistics < ActiveRecord::Migration[6.0]
+  def change
+    create_table :project_access_statistics do |t|
+      t.date :date_on, null: false
+      t.references :project, type: :integer, null: false, foreign_key: true
+      t.integer :access_count, null: false, default: 0
+
+      t.timestamps
+
+      t.index %i[date_on project_id]
+    end
+  end
+end

--- a/db/migrate/20200819134327_create_project_access_statistics.rb
+++ b/db/migrate/20200819134327_create_project_access_statistics.rb
@@ -7,7 +7,7 @@ class CreateProjectAccessStatistics < ActiveRecord::Migration[6.0]
 
       t.timestamps
 
-      t.index %i[date_on project_id]
+      t.index %i[date_on project_id], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_134327) do
     t.index ["attachable_type", "attachable_id"], name: "index_attachments_attachable"
   end
 
-  create_table "black_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", comment: "アクセスランキングブラックリスト", force: :cascade do |t|
+  create_table "black_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", comment: "アクセスランキングブラックリスト", force: :cascade do |t|
     t.integer "project_id", null: false, comment: "ブラックリスト対象プロジェクト"
     t.integer "user_id", null: false, comment: "登録した管理者"
     t.text "reason", null: false, comment: "理由"
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_134327) do
     t.index ["contributor_id"], name: "index_contributions_contributor_id"
   end
 
-  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -181,7 +181,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_134327) do
     t.index ["notifier_id"], name: "index_notifications_on_notifier_id"
   end
 
-  create_table "project_access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "project_access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "project_id", null: false
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -267,6 +267,10 @@ ActiveRecord::Schema.define(version: 2020_08_19_134327) do
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
+  add_foreign_key "black_lists", "projects"
+  add_foreign_key "black_lists", "users"
+  add_foreign_key "card_comments", "cards"
+  add_foreign_key "card_comments", "users", name: "fk_comments_user_id"
   add_foreign_key "cards", "projects", name: "fk_cards_project_id"
   add_foreign_key "contributions", "cards"
   add_foreign_key "contributions", "users", column: "contributor_id", name: "fk_contributions_contributor_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_17_060121) do
+ActiveRecord::Schema.define(version: 2020_08_19_134327) do
 
   create_table "attachments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "content"
@@ -190,6 +190,16 @@ ActiveRecord::Schema.define(version: 2019_08_17_060121) do
     t.index ["user_id"], name: "index_project_access_logs_on_user_id"
   end
 
+  create_table "project_access_statistics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.date "date_on", null: false
+    t.integer "project_id", null: false
+    t.integer "access_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["date_on", "project_id"], name: "index_project_access_statistics_on_date_on_and_project_id"
+    t.index ["project_id"], name: "index_project_access_statistics_on_project_id"
+  end
+
   create_table "project_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.text "body", null: false
     t.integer "user_id", null: false
@@ -257,10 +267,6 @@ ActiveRecord::Schema.define(version: 2019_08_17_060121) do
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
-  add_foreign_key "black_lists", "projects"
-  add_foreign_key "black_lists", "users"
-  add_foreign_key "card_comments", "cards"
-  add_foreign_key "card_comments", "users", name: "fk_comments_user_id"
   add_foreign_key "cards", "projects", name: "fk_cards_project_id"
   add_foreign_key "contributions", "cards"
   add_foreign_key "contributions", "users", column: "contributor_id", name: "fk_contributions_contributor_id"
@@ -271,6 +277,7 @@ ActiveRecord::Schema.define(version: 2019_08_17_060121) do
   add_foreign_key "notifications", "users", column: "notifier_id", name: "fk_notifications_notifier_id"
   add_foreign_key "project_access_logs", "projects"
   add_foreign_key "project_access_logs", "users"
+  add_foreign_key "project_access_statistics", "projects"
   add_foreign_key "project_comments", "projects"
   add_foreign_key "project_comments", "users"
   add_foreign_key "tags", "projects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_134327) do
     t.integer "access_count", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["date_on", "project_id"], name: "index_project_access_statistics_on_date_on_and_project_id"
+    t.index ["date_on", "project_id"], name: "index_project_access_statistics_on_date_on_and_project_id", unique: true
     t.index ["project_id"], name: "index_project_access_statistics_on_project_id"
   end
 

--- a/lib/tasks/statistic.rake
+++ b/lib/tasks/statistic.rake
@@ -1,0 +1,22 @@
+namespace :statistic do
+  task daily: :environment do
+    yesterday = Time.current.to_date
+    TakeStatisticsService.call(yesterday)
+  end
+
+  task monthly: :environment do
+    date_on = 1.month.ago.to_date
+    while date_on <= Date.today
+      TakeStatisticsService.call(date_on)
+      date_on = date_on + 1
+    end
+  end
+
+  task all: :environment do
+    date_on = (ProjectAccessLog.minimum(:created_at) || Time.current).to_date
+    while date_on <= Date.today
+      TakeStatisticsService.call(date_on)
+      date_on = date_on + 1
+    end
+  end
+end

--- a/spec/factories/black_lists.rb
+++ b/spec/factories/black_lists.rb
@@ -2,12 +2,12 @@
 #
 # Table name: black_lists
 #
-#  id                          :bigint(8)        not null, primary key
-#  reason(理由)                  :text(65535)      not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                                         :bigint(8)        not null, primary key
+#  reason(理由)                               :text(65535)      not null
+#  created_at                                 :datetime         not null
+#  updated_at                                 :datetime         not null
 #  project_id(ブラックリスト対象プロジェクト) :integer          not null
-#  user_id(登録した管理者)            :integer          not null
+#  user_id(登録した管理者)                    :integer          not null
 #
 # Indexes
 #

--- a/spec/factories/project_access_statistics.rb
+++ b/spec/factories/project_access_statistics.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: project_access_statistics
+#
+#  id           :bigint(8)        not null, primary key
+#  access_count :integer          default(0), not null
+#  date_on      :date             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  project_id   :integer          not null
+#
+# Indexes
+#
+#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id)
+#  index_project_access_statistics_on_project_id              (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#
+
+FactoryBot.define do
+  factory :project_access_statistic do
+    date_on { rand(0..7).days.ago.to_date }
+    association :project, factory: %i[project public]
+    access_count { rand(10000) }
+  end
+end

--- a/spec/factories/project_access_statistics.rb
+++ b/spec/factories/project_access_statistics.rb
@@ -11,7 +11,7 @@
 #
 # Indexes
 #
-#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id)
+#  index_project_access_statistics_on_date_on_and_project_id  (date_on,project_id) UNIQUE
 #  index_project_access_statistics_on_project_id              (project_id)
 #
 # Foreign Keys

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -31,7 +31,7 @@ describe Group do
 
     it do
       expect(Group.access_ranking).to match_array([group2, group1, group3])
-      expect(Group.access_ranking(since: 5.days.ago - 1.minute)).to match_array([group2, group3])
+      expect(Group.access_ranking(from: 5.days.ago - 1.minute, to: Time.current)).to match_array([group2, group3])
       expect(Group.access_ranking(limit: 1)).to match_array([group2])
     end
   end

--- a/spec/models/project_access_statistic_spec.rb
+++ b/spec/models/project_access_statistic_spec.rb
@@ -1,3 +1,24 @@
 RSpec.describe ProjectAccessStatistic, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.access_ranking' do
+    example do
+      yesterday = Date.yesterday
+      last_month = (yesterday - 1.month).to_date
+
+      project_a = FactoryBot.create(:project)
+      project_b = FactoryBot.create(:project)
+      project_c = FactoryBot.create(:project)
+
+      # project_a 10 + 100 = 110
+      # project_b 10 + 100 + 1000 = 1110
+      FactoryBot.create(:project_access_statistic, date_on: yesterday, project: project_a, access_count: 10)
+      FactoryBot.create(:project_access_statistic, date_on: last_month, project: project_a, access_count: 100)
+      FactoryBot.create(:project_access_statistic, date_on: last_month - 1, project: project_a, access_count: 1000)
+      FactoryBot.create(:project_access_statistic, date_on: yesterday, project: project_b, access_count: 10)
+      FactoryBot.create(:project_access_statistic, date_on: last_month, project: project_b, access_count: 100)
+      FactoryBot.create(:project_access_statistic, date_on: last_month + 1, project: project_b, access_count: 1000)
+      FactoryBot.create(:project_access_statistic, date_on: last_month - 1, project: project_c, access_count: 10)
+
+      expect(ProjectAccessStatistic.access_ranking(from: last_month, to: yesterday)).to eq [project_b, project_a]
+    end
+  end
 end

--- a/spec/models/project_access_statistic_spec.rb
+++ b/spec/models/project_access_statistic_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe ProjectAccessStatistic, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -70,8 +70,9 @@ describe Project do
 
     it do
       expect(Project.access_ranking).to match_array([project3, project2, project1])
-      expect(Project.access_ranking(since: 5.days.ago - 1.minute)).to match_array([project2, project3])
+      expect(Project.access_ranking(from: 5.days.ago - 1.minute, to: Time.current)).to match_array([project2, project3])
       expect(Project.access_ranking(limit: 1)).to match_array([project3])
+      expect(Project.access_ranking[0].access_count).to eq 4
     end
   end
 

--- a/spec/services/take_statistics_service_spec.rb
+++ b/spec/services/take_statistics_service_spec.rb
@@ -1,0 +1,36 @@
+describe TakeStatisticsService do
+  describe '.call' do
+    before do
+      FactoryBot.create_list(:project_access_log, 5, project: project, created_at: yesterday)
+      FactoryBot.create_list(:project_access_log, 10, project: FactoryBot.create(:project), created_at: yesterday)
+      FactoryBot.create(:project_access_log, project: project, created_at: today)
+      FactoryBot.create(:project_access_log, project: FactoryBot.create(:project), created_at: today)
+      FactoryBot.create(:project)
+    end
+
+    let(:today) { Time.current }
+    let(:yesterday) { today.yesterday }
+    let(:project) { FactoryBot.create(:project) }
+
+    it do
+      expect { TakeStatisticsService.call(yesterday.to_date) }.to change(ProjectAccessStatistic, :count).by(2)
+    end
+
+    describe 'ProjectAccessStatistic' do
+      before { TakeStatisticsService.call(yesterday.to_date) }
+      subject(:project_access_statistic) { ProjectAccessStatistic.find_by(project: project) }
+
+      it do
+        expect(project_access_statistic).to be_an_instance_of(ProjectAccessStatistic)
+      end
+
+      it do
+        expect(project_access_statistic.date_on).to eq yesterday.to_date
+      end
+
+      it do
+        expect(project_access_statistic.access_count).to eq 5
+      end
+    end
+  end
+end


### PR DESCRIPTION
アクセス増加に伴いトップページ POPULAR PROJECT の集計負荷が大きくなっているので、この対策を行う。

- 前日のアクセス数を集計し日次で記録
- 日次をつかってランキングを作成

![image](https://user-images.githubusercontent.com/60980/90669589-d7ad9e80-e28c-11ea-812d-9c14e41d30a7.png)
