### PR TITLE
mimemagic ライセンス違反のあったコードを置き換えたバージョンに更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,9 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
0.3.5 は yank されてしまってインストールできない。
ライセンス違反のあったコードを置き換えたバージョンに更新する。