### PR TITLE
rubyの非推奨警告をSentryに報告する

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative "../lib/core_ext/warning"
 require_relative "../lib/middlewares/jp_only"
 require_relative "../lib/middlewares/maintenance_mode"
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -44,3 +44,16 @@ Sentry.init do |config|
       end
     end
 end
+
+ActiveSupport::Notifications.subscribe("deprecation.rails") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  message = event.payload[:message]
+  Sentry.capture_message(message, level: :warning)
+end
+
+ActiveSupport::Notifications.subscribe("deprecation.ruby") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  message = event.payload[:message]
+  Sentry.capture_message(message, level: :warning)
+end
+

--- a/lib/core_ext/warning.rb
+++ b/lib/core_ext/warning.rb
@@ -1,0 +1,12 @@
+# TODO: Ruby 2.7 にしたらコメントを外す
+# Warning[:deprecated] = true
+
+module Warning
+  alias_method :original_warn, :warn
+ 
+  def warn(msg)
+    return original_warn(msg) unless msg.include?("deprecated")
+    ActiveSupport::Notifications.instrument "deprecation.ruby", message: msg
+    original_warn(msg)
+  end
+end


### PR DESCRIPTION
Rubyアップグレード準備のため、非推奨警告は都度記録し対応できるようにする
