### PR TITLE
fix: Use libvips instead of ImageMagick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'friendly_id'
 gem 'jb'
 gem 'jbuilder'
 gem 'kaminari'
-gem 'mini_magick', '~> 4.10'
 gem 'observer'
 gem "mimemagic", "~> 0.4.3"
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,7 +527,6 @@ DEPENDENCIES
   maxmind-db
   meta_request
   mimemagic (~> 0.4.3)
-  mini_magick (~> 4.10)
   mysql2
   nested_form
   net-http

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,7 +1,5 @@
 class AvatarUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  include CarrierWave::MiniMagick
+  include CarrierWave::Vips
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/views/components/_card_figures.html.slim
+++ b/app/views/components/_card_figures.html.slim
@@ -38,9 +38,9 @@
           .carousel-inner
             - figures.each do |figure|
               - next if figure.content.blank?
-              - url = defined?(note_card_show) ? figure.content.medium.url : figure.content.small.url
+              - url = figure.content.url
               div class="carousel-item #{'active' if count.zero?}"
-                = image_tag url, class: "d-block w-100 clickable-img", alt: figure.content.filename
+                = image_tag url, class: "d-block w-100 clickable-img", alt: figure.content.filename, loading: "lazy"
                 - count += 1
             - attachments.each do |attachment|
               - if attachment.content.tmp.url&.end_with?(".png")

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -8,6 +8,7 @@ RUN apt-get update -qq \
   default-mysql-client \
   nodejs npm vim \
   povray povray-includes \
+  libvips \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -7,7 +7,7 @@ RUN apt-get update -qq \
   && apt-get install --no-install-recommends -y \
     nodejs npm vim \
     povray povray-includes \
-    imagemagick \
+    imagemagick libvips \
     cron sudo \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/spec/fixtures/files/stls/cube-ascii.stl
+++ b/spec/fixtures/files/stls/cube-ascii.stl
@@ -1,0 +1,86 @@
+solid cube-ascii
+    facet normal  0.000000e+00  0.000000e+00  1.000000e+00
+        outer loop
+            vertex  0.000000e+00  0.000000e+00  1.000000e+01
+            vertex  1.000000e+01  0.000000e+00  1.000000e+01
+            vertex  0.000000e+00  1.000000e+01  1.000000e+01
+        endloop
+    endfacet
+    facet normal  0.000000e+00  0.000000e+00  1.000000e+00
+        outer loop
+            vertex  1.000000e+01  1.000000e+01  1.000000e+01
+            vertex  0.000000e+00  1.000000e+01  1.000000e+01
+            vertex  1.000000e+01  0.000000e+00  1.000000e+01
+        endloop
+    endfacet
+    facet normal  1.000000e+00  0.000000e+00  0.000000e+00
+        outer loop
+            vertex  1.000000e+01  0.000000e+00  1.000000e+01
+            vertex  1.000000e+01  0.000000e+00  0.000000e+00
+            vertex  1.000000e+01  1.000000e+01  1.000000e+01
+        endloop
+    endfacet
+    facet normal  1.000000e+00  0.000000e+00  0.000000e+00
+        outer loop
+            vertex  1.000000e+01  1.000000e+01  0.000000e+00
+            vertex  1.000000e+01  1.000000e+01  1.000000e+01
+            vertex  1.000000e+01  0.000000e+00  0.000000e+00
+        endloop
+    endfacet
+    facet normal  0.000000e+00  0.000000e+00 -1.000000e+00
+        outer loop
+            vertex  1.000000e+01  0.000000e+00  0.000000e+00
+            vertex  0.000000e+00  0.000000e+00  0.000000e+00
+            vertex  1.000000e+01  1.000000e+01  0.000000e+00
+        endloop
+    endfacet
+    facet normal  0.000000e+00  0.000000e+00 -1.000000e+00
+        outer loop
+            vertex  0.000000e+00  1.000000e+01  0.000000e+00
+            vertex  1.000000e+01  1.000000e+01  0.000000e+00
+            vertex  0.000000e+00  0.000000e+00  0.000000e+00
+        endloop
+    endfacet
+    facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+        outer loop
+            vertex  0.000000e+00  0.000000e+00  0.000000e+00
+            vertex  0.000000e+00  0.000000e+00  1.000000e+01
+            vertex  0.000000e+00  1.000000e+01  0.000000e+00
+        endloop
+    endfacet
+    facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+        outer loop
+            vertex  0.000000e+00  1.000000e+01  1.000000e+01
+            vertex  0.000000e+00  1.000000e+01  0.000000e+00
+            vertex  0.000000e+00  0.000000e+00  1.000000e+01
+        endloop
+    endfacet
+    facet normal  0.000000e+00  1.000000e+00  0.000000e+00
+        outer loop
+            vertex  0.000000e+00  1.000000e+01  1.000000e+01
+            vertex  1.000000e+01  1.000000e+01  1.000000e+01
+            vertex  0.000000e+00  1.000000e+01  0.000000e+00
+        endloop
+    endfacet
+    facet normal  0.000000e+00  1.000000e+00  0.000000e+00
+        outer loop
+            vertex  1.000000e+01  1.000000e+01  0.000000e+00
+            vertex  0.000000e+00  1.000000e+01  0.000000e+00
+            vertex  1.000000e+01  1.000000e+01  1.000000e+01
+        endloop
+    endfacet
+    facet normal  0.000000e+00 -1.000000e+00  0.000000e+00
+        outer loop
+            vertex  1.000000e+01  0.000000e+00  1.000000e+01
+            vertex  0.000000e+00  0.000000e+00  1.000000e+01
+            vertex  1.000000e+01  0.000000e+00  0.000000e+00
+        endloop
+    endfacet
+    facet normal  0.000000e+00 -1.000000e+00  0.000000e+00
+        outer loop
+            vertex  0.000000e+00  0.000000e+00  0.000000e+00
+            vertex  1.000000e+01  0.000000e+00  0.000000e+00
+            vertex  0.000000e+00  0.000000e+00  1.000000e+01
+        endloop
+    endfacet
+endsolid

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -18,4 +18,18 @@ describe Attachment do
       it { expect(subject.content.file.content_type).to eq(attachment.content.file.content_type) }
     end
   end
+
+  context 'when attachment is an stl' do
+    let(:attachment) do
+      content = Rack::Test::UploadedFile.new(
+        Rails.root.join('spec', 'fixtures', 'files', 'stls', 'cube-ascii.stl'),
+        'model/stl'
+      )
+      build(:attachment, content:)
+    end
+
+    it "保存できること" do
+      expect(attachment.save).to eq true
+    end
+  end
 end

--- a/spec/models/figure_spec.rb
+++ b/spec/models/figure_spec.rb
@@ -31,4 +31,18 @@ describe Figure do
       end
     end
   end
+
+  context 'アニメーションGIFのとき' do
+    let(:figure) do
+      content = Rack::Test::UploadedFile.new(
+        Rails.root.join('spec', 'fixtures', 'files', 'images', 'animation.gif'),
+        'image/gif'
+      )
+      build(:content_figure, content:)
+    end
+
+    it "保存できること" do
+      expect(figure.save).to eq true
+    end
+  end
 end


### PR DESCRIPTION
close #157

libvips (ruby-vips) は Rails 7 からの標準
ImageMagickによるリサイズによる負荷でforkが遅くなっていた
特にgifによる操作案内を多用する https://fabble.cc/fabble/tutorial ではタイムアウトしていた

本PRにおいて
ImageMagick (mini_magick) を使用したリサイズや画像合成処理を、libvips (ruby-vips) を用いるように変更した。

本修正によりforkできるようになった
https://fabble.cc/takeyuwebinc/tutorial

またアニメーションGIFをfigureに指定した場合、縮小＆再生ボタンを合成していたが、モーダルの表示に問題があり、クリックしても再生できなくなっていたのを修正した。
![image](https://github.com/user-attachments/assets/ee58972e-1d4a-40b2-9f17-8b9e23a04919)
