### PR TITLE
Issue/comment spam

### DIFF
--- a/app/assets/stylesheets/admin/card_comments/index.css
+++ b/app/assets/stylesheets/admin/card_comments/index.css
@@ -1,0 +1,17 @@
+.card-comments-table {
+  table-layout: fixed;
+}
+.card-comments-table .status {
+  width: 100px;
+}
+.card-comments-table .commenter {
+  width: 150px;
+  word-break: break-all;
+}
+.card-comments-table .project-name {
+  width: 200px;
+  word-break: break-all;
+}
+.card-comments-table .management {
+  width: 100px;
+}

--- a/app/assets/stylesheets/admin/project_comments/index.css
+++ b/app/assets/stylesheets/admin/project_comments/index.css
@@ -1,0 +1,17 @@
+.project-comments-table {
+  table-layout: fixed;
+}
+.project-comments-table .status {
+  width: 100px;
+}
+.project-comments-table .commenter {
+  width: 150px;
+  word-break: break-all;
+}
+.project-comments-table .project-name {
+  width: 200px;
+  word-break: break-all;
+}
+.project-comments-table .management {
+  width: 100px;
+}

--- a/app/controllers/admin/card_comments/approvals_controller.rb
+++ b/app/controllers/admin/card_comments/approvals_controller.rb
@@ -1,0 +1,3 @@
+class Admin::CardComments::ApprovalsController < Admin::Comments::ApprovalsController
+end
+  

--- a/app/controllers/admin/card_comments/spam_batches_controller.rb
+++ b/app/controllers/admin/card_comments/spam_batches_controller.rb
@@ -1,0 +1,3 @@
+class Admin::CardComments::SpamBatchesController < Admin::Comments::SpamBatchesController
+end
+ 

--- a/app/controllers/admin/card_comments/spams_controller.rb
+++ b/app/controllers/admin/card_comments/spams_controller.rb
@@ -1,0 +1,2 @@
+class Admin::CardComments::SpamsController < Admin::Comments::SpamsController
+end

--- a/app/controllers/admin/card_comments_controller.rb
+++ b/app/controllers/admin/card_comments_controller.rb
@@ -1,7 +1,7 @@
 class Admin::CardCommentsController < Admin::ApplicationController
   def index
     @status = params[:status]
-    card_comments = CardComment.preload(:card).order(id: :desc)
+    card_comments = CardComment.preload(:card, :user).order(id: :desc)
     card_comments.where!(status: @status) if @status.present?
     @card_comments = card_comments.page(params[:page]).per(100)
   end

--- a/app/controllers/admin/card_comments_controller.rb
+++ b/app/controllers/admin/card_comments_controller.rb
@@ -1,0 +1,8 @@
+class Admin::CardCommentsController < Admin::ApplicationController
+  def index
+    @status = params[:status]
+    card_comments = CardComment.preload(:card).order(id: :desc)
+    card_comments.where!(status: @status) if @status.present?
+    @card_comments = card_comments.page(params[:page]).per(100)
+  end
+end

--- a/app/controllers/admin/comments/approvals_controller.rb
+++ b/app/controllers/admin/comments/approvals_controller.rb
@@ -1,0 +1,11 @@
+class Admin::Comments::ApprovalsController < Admin::Comments::BaseController
+  def create
+    fetch_comment.approve!
+    redirect_to public_send(:"admin_#{comment_class.name.underscore.pluralize}_path", status: params[:status]), notice: "コメントを承認しました"
+  end
+
+  def destroy
+    fetch_comment.unapprove!
+    redirect_to public_send(:"admin_#{comment_class.name.underscore.pluralize}_path", status: params[:status]), notice: "コメントの承認を取り消ししました"
+  end
+end

--- a/app/controllers/admin/comments/base_controller.rb
+++ b/app/controllers/admin/comments/base_controller.rb
@@ -1,0 +1,15 @@
+class Admin::Comments::BaseController < Admin::ApplicationController
+  private
+
+  def comment_class
+    self.class.name.split(/::/)[-2].singularize.constantize
+  end
+
+  def comment_id
+    params[:"#{comment_class.name.underscore}_id"]
+  end
+
+  def fetch_comment
+    comment_class.find(comment_id)
+  end
+end

--- a/app/controllers/admin/comments/spam_batches_controller.rb
+++ b/app/controllers/admin/comments/spam_batches_controller.rb
@@ -1,0 +1,9 @@
+class Admin::Comments::SpamBatchesController < Admin::Comments::BaseController
+  def create
+    comment_class.unconfirmed.where("created_at <= ?", Time.zone.parse(params[:before])).order(id: :asc).find_each do |comment|
+      comment.mark_spam!
+    end
+    redirect_to public_send(:"admin_#{comment_class.name.underscore.pluralize}_path", status: params[:status]), notice: "コメントをスパムとして記録しました"
+  end
+end
+ 

--- a/app/controllers/admin/comments/spams_controller.rb
+++ b/app/controllers/admin/comments/spams_controller.rb
@@ -1,0 +1,11 @@
+class Admin::Comments::SpamsController < Admin::Comments::BaseController
+  def create
+    fetch_comment.mark_spam!
+    redirect_to public_send(:"admin_#{comment_class.name.underscore.pluralize}_path", status: params[:status]), notice: "コメントをスパムとして記録しました"
+  end
+
+  def destroy
+    fetch_comment.unmark_spam!
+    redirect_to public_send(:"admin_#{comment_class.name.underscore.pluralize}_path", status: params[:status]), notice: "スパムコメントを未確認に戻しました"
+  end
+end

--- a/app/controllers/admin/project_comments/approvals_controller.rb
+++ b/app/controllers/admin/project_comments/approvals_controller.rb
@@ -1,0 +1,14 @@
+class Admin::ProjectComments::ApprovalsController < Admin::ApplicationController
+  def create
+    @project_comment = ProjectComment.find(params[:project_comment_id])
+    @project_comment.approve!
+    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントを承認しました"
+  end
+
+  def destroy
+    @project_comment = ProjectComment.find(params[:project_comment_id])
+    @project_comment.unapprove!
+    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントの承認を取り消ししました"
+  end
+end
+  

--- a/app/controllers/admin/project_comments/approvals_controller.rb
+++ b/app/controllers/admin/project_comments/approvals_controller.rb
@@ -1,14 +1,3 @@
-class Admin::ProjectComments::ApprovalsController < Admin::ApplicationController
-  def create
-    @project_comment = ProjectComment.find(params[:project_comment_id])
-    @project_comment.approve!
-    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントを承認しました"
-  end
-
-  def destroy
-    @project_comment = ProjectComment.find(params[:project_comment_id])
-    @project_comment.unapprove!
-    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントの承認を取り消ししました"
-  end
+class Admin::ProjectComments::ApprovalsController < Admin::Comments::ApprovalsController
 end
   

--- a/app/controllers/admin/project_comments/spam_batches_controller.rb
+++ b/app/controllers/admin/project_comments/spam_batches_controller.rb
@@ -1,0 +1,9 @@
+class Admin::ProjectComments::SpamBatchesController < Admin::ApplicationController
+  def create
+    ProjectComment.unconfirmed.where("created_at <= ?", Time.zone.parse(params[:before])).order(id: :asc).find_each do |project_comment|
+      project_comment.mark_spam!
+    end
+    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントをスパムとして記録しました"
+  end
+end
+ 

--- a/app/controllers/admin/project_comments/spam_batches_controller.rb
+++ b/app/controllers/admin/project_comments/spam_batches_controller.rb
@@ -1,9 +1,3 @@
-class Admin::ProjectComments::SpamBatchesController < Admin::ApplicationController
-  def create
-    ProjectComment.unconfirmed.where("created_at <= ?", Time.zone.parse(params[:before])).order(id: :asc).find_each do |project_comment|
-      project_comment.mark_spam!
-    end
-    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントをスパムとして記録しました"
-  end
+class Admin::ProjectComments::SpamBatchesController < Admin::Comments::SpamBatchesController
 end
  

--- a/app/controllers/admin/project_comments/spams_controller.rb
+++ b/app/controllers/admin/project_comments/spams_controller.rb
@@ -1,14 +1,2 @@
-class Admin::ProjectComments::SpamsController < Admin::ApplicationController
-  def create
-    @project_comment = ProjectComment.find(params[:project_comment_id])
-    @project_comment.mark_spam!
-    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントをスパムとして記録しました"
-  end
-
-  def destroy
-    @project_comment = ProjectComment.find(params[:project_comment_id])
-    @project_comment.unmark_spam!
-    redirect_to admin_project_comments_path(status: params[:status]), notice: "スパムコメントを未確認に戻しました"
-  end
+class Admin::ProjectComments::SpamsController < Admin::Comments::SpamsController
 end
-    

--- a/app/controllers/admin/project_comments/spams_controller.rb
+++ b/app/controllers/admin/project_comments/spams_controller.rb
@@ -1,0 +1,14 @@
+class Admin::ProjectComments::SpamsController < Admin::ApplicationController
+  def create
+    @project_comment = ProjectComment.find(params[:project_comment_id])
+    @project_comment.mark_spam!
+    redirect_to admin_project_comments_path(status: params[:status]), notice: "コメントをスパムとして記録しました"
+  end
+
+  def destroy
+    @project_comment = ProjectComment.find(params[:project_comment_id])
+    @project_comment.unmark_spam!
+    redirect_to admin_project_comments_path(status: params[:status]), notice: "スパムコメントを未確認に戻しました"
+  end
+end
+    

--- a/app/controllers/admin/project_comments_controller.rb
+++ b/app/controllers/admin/project_comments_controller.rb
@@ -1,0 +1,8 @@
+class Admin::ProjectCommentsController < Admin::ApplicationController
+  def index
+    @status = params[:status]
+    project_comments = ProjectComment.preload(:project).order(id: :desc)
+    project_comments.where!(status: @status) if @status.present?
+    @project_comments = project_comments.page(params[:page]).per(100)
+  end
+end

--- a/app/controllers/admin/project_comments_controller.rb
+++ b/app/controllers/admin/project_comments_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ProjectCommentsController < Admin::ApplicationController
   def index
     @status = params[:status]
-    project_comments = ProjectComment.preload(:project).order(id: :desc)
+    project_comments = ProjectComment.preload(:project, :user).order(id: :desc)
     project_comments.where!(status: @status) if @status.present?
     @project_comments = project_comments.page(params[:page]).per(100)
   end

--- a/app/controllers/admin/spammers_controller.rb
+++ b/app/controllers/admin/spammers_controller.rb
@@ -1,0 +1,10 @@
+class Admin::SpammersController < Admin::ApplicationController
+  def index
+    @spammers = Spammer.eager_load(:user).order(created_at: :desc).page(params[:page]).per(100)
+  end
+
+  def destroy
+    Spammer.find(params[:id]).destroy!
+    redirect_to admin_spammers_path, notice: 'スパム報告を削除しました'
+  end
+end

--- a/app/controllers/project_comments_controller.rb
+++ b/app/controllers/project_comments_controller.rb
@@ -1,8 +1,7 @@
 class ProjectCommentsController < ApplicationController
   def create
     project = Project.find(params[:project_id])
-    project_comment = project.project_comments.build(project_comment_params)
-    project_comment.status = 'spam' if current_user.spammer?
+    project_comment = ProjectComment.build_from(project, current_user, project_comment_params)
 
     if project_comment.save
       notify_users(project)
@@ -35,7 +34,7 @@ class ProjectCommentsController < ApplicationController
   private
 
     def project_comment_params
-      params.require(:project_comment).permit(:body).merge(user: current_user)
+      params.require(:project_comment).permit(:body)
     end
 
     def notify_users(project)

--- a/app/controllers/project_comments_controller.rb
+++ b/app/controllers/project_comments_controller.rb
@@ -2,6 +2,7 @@ class ProjectCommentsController < ApplicationController
   def create
     project = Project.find(params[:project_id])
     project_comment = project.project_comments.build(project_comment_params)
+    project_comment.status = 'spam' if current_user.spammer?
 
     if project_comment.save
       notify_users(project)

--- a/app/controllers/project_comments_controller.rb
+++ b/app/controllers/project_comments_controller.rb
@@ -4,7 +4,7 @@ class ProjectCommentsController < ApplicationController
     project_comment = ProjectComment.build_from(project, current_user, project_comment_params)
 
     if project_comment.save
-      notify_users(project)
+      notify_users(project_comment)
       redirect_to project_path(project.owner, project, anchor: "project-comment-#{project_comment.id}")
     else
       redirect_to project_path(project.owner, project, anchor: "project-comment-form"),
@@ -37,11 +37,13 @@ class ProjectCommentsController < ApplicationController
       params.require(:project_comment).permit(:body)
     end
 
-    def notify_users(project)
+    def notify_users(project_comment)
+      return if project_comment.spam?
+      project = project_comment.project
       users = project.notifiable_users(current_user)
       return if users.blank?
 
       body = "#{current_user.name} commented on #{project.title}."
-      project.notify(users, current_user, project_path(project.owner, project), body)
+      project.notify(users, project_comment.user, project_path(project.owner, project), body)
     end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,8 +23,8 @@ class ProjectsController < ApplicationController
     end
 
     ProjectAccessLog.log!(@project, current_user)
-    @project_comments = @project.project_comments.includes(:user).order(:id)
-    @states = @project.states.includes(:attachments, :contributors, :figures, comments: [:user], annotations: [:attachments, :figures, :contributors, comments: [:user]]).ordered_by_position
+    @project_comments = @project.visible_project_comments.includes(:user).order(:id)
+    @states = @project.states.includes(:attachments, :contributors, :figures, visible_comments: [:user], annotations: [:attachments, :figures, :contributors, visible_comments: [:user]]).ordered_by_position
     @usages = @project.usages.includes(:attachments, :figures, :contributors, contributions: [:contributor])
   end
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -29,6 +29,7 @@ class Card < ApplicationRecord
   has_many :attachments, as: :attachable, dependent: :destroy
   accepts_nested_attributes_for :attachments
   has_many :comments, class_name: "CardComment", dependent: :destroy
+  has_many :visible_comments, -> { not_spam }, class_name: 'CardComment'
   has_many :contributions, dependent: :destroy
   has_many :contributors, through: :contributions, class_name: "User"
 

--- a/app/models/card_comment.rb
+++ b/app/models/card_comment.rb
@@ -2,13 +2,13 @@
 #
 # Table name: card_comments
 #
-#  id                             :integer          not null, primary key
-#  body                           :text(65535)
-#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
-#  card_id                        :integer          not null
-#  user_id                        :integer          not null
+#  id                                                  :integer          not null, primary key
+#  body                                                :text(65535)
+#  status(確認ステータス 0:未確認 1:承認済み 2:スパム) :integer          default("unconfirmed"), not null
+#  created_at                                          :datetime
+#  updated_at                                          :datetime
+#  card_id                                             :integer          not null
+#  user_id                                             :integer          not null
 #
 # Indexes
 #
@@ -27,5 +27,5 @@ class CardComment < ApplicationRecord
 
   validates :body, presence: true
 
-  scope :not_spam, -> { where(spam: false) }
+  enum :status, { unconfirmed: 0, approved: 1, spam: 2 }
 end

--- a/app/models/card_comment.rb
+++ b/app/models/card_comment.rb
@@ -2,12 +2,13 @@
 #
 # Table name: card_comments
 #
-#  id         :integer          not null, primary key
-#  body       :text(65535)
-#  created_at :datetime
-#  updated_at :datetime
-#  card_id    :integer          not null
-#  user_id    :integer          not null
+#  id                             :integer          not null, primary key
+#  body                           :text(65535)
+#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  card_id                        :integer          not null
+#  user_id                        :integer          not null
 #
 # Indexes
 #
@@ -25,4 +26,6 @@ class CardComment < ApplicationRecord
   belongs_to :user
 
   validates :body, presence: true
+
+  scope :not_spam, -> { where(spam: false) }
 end

--- a/app/models/card_comment.rb
+++ b/app/models/card_comment.rb
@@ -22,10 +22,19 @@
 #
 
 class CardComment < ApplicationRecord
+  include SpamCommentable
   belongs_to :card, counter_cache: :comments_count
   belongs_to :user
 
   validates :body, presence: true
 
-  enum :status, { unconfirmed: 0, approved: 1, spam: 2 }
+  # コメントオブジェクトを作成する
+  # 投稿者がスパム投稿者の場合、スパムコメントとして作成する
+  def self.build_from(card, user, params)
+    build(params).tap do |card_comment|
+      card_comment.card = card
+      card_comment.user = user
+      card_comment.status = :spam if user.spammer?
+    end
+  end
 end

--- a/app/models/concerns/spam_commentable.rb
+++ b/app/models/concerns/spam_commentable.rb
@@ -1,0 +1,35 @@
+module SpamCommentable
+  extend ActiveSupport::Concern
+
+  included do
+    enum :status, { unconfirmed: 0, approved: 1, spam: 2 }
+  end
+
+  # コメントを承認する
+  def approve!
+    update!(status: :approved)
+  end
+
+  # コメントの承認を解除する
+  def unapprove!
+    return if unconfirmed?
+    raise "Can't unapprove spam comment" if spam?
+    update!(status: :unconfirmed)
+  end
+
+  # コメントをスパムとして記録する
+  def mark_spam!
+    with_lock do
+      user.notifications_given.destroy_all
+      user.spam_detect!
+      update!(status: :spam)
+    end
+  end
+
+  # スパムコメントを未確認に戻す
+  def unmark_spam!
+    return if unconfirmed?
+    raise "Can't unmark spam approved comment" if approved?
+    update!(status: :unconfirmed)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,6 +49,7 @@ class Project < ApplicationRecord
   has_many :tags, dependent: :destroy
   has_many :usages, class_name: 'Card::Usage', dependent: :destroy
   has_many :project_comments, dependent: :destroy
+  has_many :visible_project_comments, -> { not_spam }, class_name: 'ProjectComment'
   has_many :project_access_logs, dependent: :destroy
   has_many :project_access_statistics, dependent: :destroy
 

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -47,7 +47,10 @@ class ProjectComment < ApplicationRecord
 
   # コメントをスパムとして記録する
   def mark_spam!
-    update!(status: :spam)
+    with_lock do
+      user.notifications_given.destroy_all
+      update!(status: :spam)
+    end
   end
 
   # スパムコメントを未確認に戻す

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -2,13 +2,13 @@
 #
 # Table name: project_comments
 #
-#  id                             :bigint(8)        not null, primary key
-#  body                           :text(65535)      not null
-#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  project_id                     :integer          not null
-#  user_id                        :integer          not null
+#  id                                                  :bigint(8)        not null, primary key
+#  body                                                :text(65535)      not null
+#  status(確認ステータス 0:未確認 1:承認済み 2:スパム) :integer          default("unconfirmed"), not null
+#  created_at                                          :datetime         not null
+#  updated_at                                          :datetime         not null
+#  project_id                                          :integer          not null
+#  user_id                                             :integer          not null
 #
 # Indexes
 #
@@ -27,9 +27,33 @@ class ProjectComment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 300 }
 
-  scope :not_spam, -> { where(spam: false) }
+  enum :status, { unconfirmed: 0, approved: 1, spam: 2 }
 
   def manageable_by?(user)
     self.user == user || project.manageable_by?(user)
+  end
+
+  # コメントを承認する
+  def approve!
+    update!(status: :approved)
+  end
+
+  # コメントの承認を解除する
+  def unapprove!
+    return if unconfirmed?
+    raise "Can't unapprove spam comment" if spam?
+    update!(status: :unconfirmed)
+  end
+
+  # コメントをスパムとして記録する
+  def mark_spam!
+    update!(status: :spam)
+  end
+
+  # スパムコメントを未確認に戻す
+  def unmark_spam!
+    return if unconfirmed?
+    raise "Can't unmark spam approved comment" if approved?
+    update!(status: :unconfirmed)
   end
 end

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -60,4 +60,14 @@ class ProjectComment < ApplicationRecord
     raise "Can't unmark spam approved comment" if approved?
     update!(status: :unconfirmed)
   end
+
+  # コメントオブジェクトを作成する
+  # 投稿者がスパム投稿者の場合、スパムコメントとして作成する
+  def self.build_from(project, user, params)
+    build(params).tap do |project_comment|
+      project_comment.project = project
+      project_comment.user = user
+      project_comment.status = :spam if user.spammer?
+    end
+  end
 end

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -22,43 +22,14 @@
 #
 
 class ProjectComment < ApplicationRecord
+  include SpamCommentable
   belongs_to :user
   belongs_to :project
 
   validates :body, presence: true, length: { maximum: 300 }
 
-  enum :status, { unconfirmed: 0, approved: 1, spam: 2 }
-
   def manageable_by?(user)
     self.user == user || project.manageable_by?(user)
-  end
-
-  # コメントを承認する
-  def approve!
-    update!(status: :approved)
-  end
-
-  # コメントの承認を解除する
-  def unapprove!
-    return if unconfirmed?
-    raise "Can't unapprove spam comment" if spam?
-    update!(status: :unconfirmed)
-  end
-
-  # コメントをスパムとして記録する
-  def mark_spam!
-    with_lock do
-      user.notifications_given.destroy_all
-      user.spam_detect!
-      update!(status: :spam)
-    end
-  end
-
-  # スパムコメントを未確認に戻す
-  def unmark_spam!
-    return if unconfirmed?
-    raise "Can't unmark spam approved comment" if approved?
-    update!(status: :unconfirmed)
   end
 
   # コメントオブジェクトを作成する

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -2,12 +2,13 @@
 #
 # Table name: project_comments
 #
-#  id         :bigint(8)        not null, primary key
-#  body       :text(65535)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  project_id :integer          not null
-#  user_id    :integer          not null
+#  id                             :bigint(8)        not null, primary key
+#  body                           :text(65535)      not null
+#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  project_id                     :integer          not null
+#  user_id                        :integer          not null
 #
 # Indexes
 #
@@ -25,6 +26,8 @@ class ProjectComment < ApplicationRecord
   belongs_to :project
 
   validates :body, presence: true, length: { maximum: 300 }
+
+  scope :not_spam, -> { where(spam: false) }
 
   def manageable_by?(user)
     self.user == user || project.manageable_by?(user)

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -49,6 +49,7 @@ class ProjectComment < ApplicationRecord
   def mark_spam!
     with_lock do
       user.notifications_given.destroy_all
+      user.spam_detect!
       update!(status: :spam)
     end
   end

--- a/app/models/spammer.rb
+++ b/app/models/spammer.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: spammers
+#
+#  id                                      :bigint(8)        not null, primary key
+#  detected_at(スパムとして検知された日時) :datetime
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
+#  user_id                                 :integer          not null
+#
+# Indexes
+#
+#  index_spammers_on_user_id  (user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Spammer < ApplicationRecord
+  belongs_to :user
+  validates :detected_at, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,7 @@ class User < ApplicationRecord
   has_many :my_notifications, class_name: 'Notification', inverse_of: :notified, foreign_key: :notified_id
   has_many :project_comments, dependent: :destroy
   has_many :project_access_logs
+  has_one :spammer
 
   validates :name, unique_owner_name: true, name_format: true
   validates :email, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP, message: "format is invalid" }
@@ -164,6 +165,16 @@ class User < ApplicationRecord
         is_deleted: true
       )
     end
+  end
+
+  def spammer?
+    spammer.present?
+  end
+
+  # スパム投稿を検出した
+  def spam_detect!
+    return true if spammer?
+    create_spammer!(detected_at: Time.current)
   end
 
   private

--- a/app/views/admin/card_comments/index.html.slim
+++ b/app/views/admin/card_comments/index.html.slim
@@ -12,7 +12,7 @@
     = link_to "spam", admin_card_comments_path(status: "spam"), class: 'nav-link'
 
   .mb-3
-    - if @status == "unconfirmed" && @card_comments.length.positive?
+    - if @card_comments.length.positive?
       = button_to "すべての未確認コメントをスパムにする", admin_card_comments_spam_batch_path(before: @card_comments.first.created_at, status: @status), method: :post, data: { confirm: "スパムにしますか？" }
     - else
       = button_to "すべての未確認コメントをスパムにする", "#", disabled: true

--- a/app/views/admin/card_comments/index.html.slim
+++ b/app/views/admin/card_comments/index.html.slim
@@ -1,0 +1,48 @@
+#admin-cards-index
+  h2.h2 Review Card Comments
+
+  - flash.each do |key, message|
+    div class="alert alert-#{key}"
+      = message
+
+  nav.nav.flex-row
+    = link_to "all", admin_card_comments_path, class: 'nav-link'
+    = link_to "unconfirmed", admin_card_comments_path(status: "unconfirmed"), class: 'nav-link'
+    = link_to "approved", admin_card_comments_path(status: "approved"), class: 'nav-link'
+    = link_to "spam", admin_card_comments_path(status: "spam"), class: 'nav-link'
+
+  .mb-3
+    - if @status == "unconfirmed" && @card_comments.length.positive?
+      = button_to "すべての未確認コメントをスパムにする", admin_card_comments_spam_batch_path(before: @card_comments.first.created_at, status: @status), method: :post, data: { confirm: "スパムにしますか？" }
+    - else
+      = button_to "すべての未確認コメントをスパムにする", "#", disabled: true
+
+  table.table
+    thead
+      tr
+        th.status
+          | ステータス
+        th.body
+          | コメント
+        th.card-name
+          | プロジェクト名
+        th.management
+          | 操作
+    tbody
+    - @card_comments.each do |card_comment|
+      tr.card
+        td
+          = card_comment.status
+        td
+          = card_comment.body
+        td
+          = card_comment.card.project.title_with_owner_name
+        td
+          - if card_comment.unconfirmed?
+            = button_to "承認", admin_card_comment_approval_path(card_comment, status: @status), method: :post
+          - if card_comment.approved?
+            = button_to "未承認に戻す", admin_card_comment_approval_path(card_comment, status: @status), method: :delete
+          - if card_comment.spam?
+            = button_to "未承認に戻す", admin_card_comment_spam_path(card_comment, status: @status), method: :delete
+
+  = paginate(@card_comments)

--- a/app/views/admin/card_comments/index.html.slim
+++ b/app/views/admin/card_comments/index.html.slim
@@ -17,27 +17,31 @@
     - else
       = button_to "すべての未確認コメントをスパムにする", "#", disabled: true
 
-  table.table
+  table.table.card-comments-table
     thead
       tr
         th.status
           | ステータス
         th.body
           | コメント
-        th.card-name
+        th.commenter
+          | 投稿者
+        th.project-name
           | プロジェクト名
         th.management
           | 操作
     tbody
     - @card_comments.each do |card_comment|
       tr.card
-        td
+        td.status
           = card_comment.status
-        td
+        td.body
           = card_comment.body
-        td
+        td.commenter
+          = card_comment.user.name
+        td.project-name
           = card_comment.card.project.title_with_owner_name
-        td
+        td.management
           - if card_comment.unconfirmed?
             = button_to "承認", admin_card_comment_approval_path(card_comment, status: @status), method: :post
           - if card_comment.approved?

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -6,3 +6,4 @@
     = link_to('Porjects', admin_projects_path, class: 'nav-link')
     = link_to('トップページ画像', admin_background_path, class: 'nav-link')
     = link_to('アクセスランキングブラックリスト', admin_black_lists_path, class: 'nav-link')
+    = link_to('プロジェクトコメント', admin_project_comments_path, class: 'nav-link')

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -7,3 +7,4 @@
     = link_to('トップページ画像', admin_background_path, class: 'nav-link')
     = link_to('アクセスランキングブラックリスト', admin_black_lists_path, class: 'nav-link')
     = link_to('プロジェクトコメント', admin_project_comments_path, class: 'nav-link')
+    = link_to('スパム投稿者', admin_spammers_path, class: 'nav-link')

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -7,4 +7,5 @@
     = link_to('トップページ画像', admin_background_path, class: 'nav-link')
     = link_to('アクセスランキングブラックリスト', admin_black_lists_path, class: 'nav-link')
     = link_to('プロジェクトコメント', admin_project_comments_path, class: 'nav-link')
+    = link_to('カードコメント', admin_card_comments_path, class: 'nav-link')
     = link_to('スパム投稿者', admin_spammers_path, class: 'nav-link')

--- a/app/views/admin/project_comments/index.html.slim
+++ b/app/views/admin/project_comments/index.html.slim
@@ -1,0 +1,44 @@
+#admin-projects-index
+  h2.h2 Review Project Comments
+
+  nav.nav.flex-row
+    = link_to "all", admin_project_comments_path, class: 'nav-link'
+    = link_to "unconfirmed", admin_project_comments_path(status: "unconfirmed"), class: 'nav-link'
+    = link_to "approved", admin_project_comments_path(status: "approved"), class: 'nav-link'
+    = link_to "spam", admin_project_comments_path(status: "spam"), class: 'nav-link'
+
+  .mb-3
+    - if @status == "unconfirmed" && @project_comments.length.positive?
+      = button_to "すべての未確認コメントをスパムにする", admin_project_comments_spam_batch_path(before: @project_comments.first.created_at, status: @status), method: :post, data: { confirm: "スパムにしますか？" }
+    - else
+      = button_to "すべての未確認コメントをスパムにする", "#", disabled: true
+
+  table.table
+    thead
+      tr
+        th.status
+          | ステータス
+        th.body
+          | コメント
+        th.project-name
+          | プロジェクト名
+        th.management
+          | 操作
+    tbody
+    - @project_comments.each do |project_comment|
+      tr.project
+        td
+          = project_comment.status
+        td
+          = project_comment.body
+        td
+          = project_comment.project.title_with_owner_name
+        td
+          - if project_comment.unconfirmed?
+            = button_to "承認", admin_project_comment_approval_path(project_comment, status: @status), method: :post
+          - if project_comment.approved?
+            = button_to "未承認に戻す", admin_project_comment_approval_path(project_comment, status: @status), method: :delete
+          - if project_comment.spam?
+            = button_to "未承認に戻す", admin_project_comment_spam_path(project_comment, status: @status), method: :delete
+
+  = paginate(@project_comments)

--- a/app/views/admin/project_comments/index.html.slim
+++ b/app/views/admin/project_comments/index.html.slim
@@ -1,6 +1,10 @@
 #admin-projects-index
   h2.h2 Review Project Comments
 
+  - flash.each do |key, message|
+    div class="alert alert-#{key}"
+      = message
+
   nav.nav.flex-row
     = link_to "all", admin_project_comments_path, class: 'nav-link'
     = link_to "unconfirmed", admin_project_comments_path(status: "unconfirmed"), class: 'nav-link'

--- a/app/views/admin/project_comments/index.html.slim
+++ b/app/views/admin/project_comments/index.html.slim
@@ -12,7 +12,7 @@
     = link_to "spam", admin_project_comments_path(status: "spam"), class: 'nav-link'
 
   .mb-3
-    - if @status == "unconfirmed" && @project_comments.length.positive?
+    - if @project_comments.length.positive?
       = button_to "すべての未確認コメントをスパムにする", admin_project_comments_spam_batch_path(before: @project_comments.first.created_at, status: @status), method: :post, data: { confirm: "スパムにしますか？" }
     - else
       = button_to "すべての未確認コメントをスパムにする", "#", disabled: true

--- a/app/views/admin/project_comments/index.html.slim
+++ b/app/views/admin/project_comments/index.html.slim
@@ -17,13 +17,15 @@
     - else
       = button_to "すべての未確認コメントをスパムにする", "#", disabled: true
 
-  table.table
+  table.table.project-comments-table
     thead
       tr
         th.status
           | ステータス
         th.body
           | コメント
+        th.commenter
+          | 投稿者
         th.project-name
           | プロジェクト名
         th.management
@@ -31,13 +33,15 @@
     tbody
     - @project_comments.each do |project_comment|
       tr.project
-        td
+        td.status
           = project_comment.status
-        td
+        td.body
           = project_comment.body
-        td
+        td.commenter
+          = project_comment.user.name
+        td.project-name
           = project_comment.project.title_with_owner_name
-        td
+        td.management
           - if project_comment.unconfirmed?
             = button_to "承認", admin_project_comment_approval_path(project_comment, status: @status), method: :post
           - if project_comment.approved?

--- a/app/views/admin/spammers/index.html.slim
+++ b/app/views/admin/spammers/index.html.slim
@@ -1,0 +1,29 @@
+#admin-projects-index
+  h2.h2 Spammers
+
+  - flash.each do |key, message|
+    div class="alert alert-#{key}"
+      = message
+
+  nav.nav.flex-row
+
+  table.table
+    thead
+      tr
+        th.user
+          | ユーザー
+        th.detected_at
+          | 検出日時
+        th.management
+          | 操作
+    tbody
+    - @spammers.each do |spammer|
+      tr.project
+        td
+          = spammer.user.name
+        td
+          = l(spammer.detected_at)
+        td
+          = button_to "取り消し", admin_spammer_path(spammer), method: :post
+
+  = paginate(@spammers)

--- a/app/views/components/_card_comments.html.slim
+++ b/app/views/components/_card_comments.html.slim
@@ -3,7 +3,7 @@
   .close-comments-btn
 
   ul.comments
-    - card.comments.each_with_index do |comment, i|
+    - card.visible_comments.each_with_index do |comment, i|
       = render "card_comments/comment", comment: comment, i: i
 
   - if current_user && card.persisted?

--- a/app/views/projects/_recipe_cards.html.slim
+++ b/app/views/projects/_recipe_cards.html.slim
@@ -30,7 +30,7 @@ section#recipe-cards
     ul#recipe-card-list.card-list
       - @states.each do |state|
         li class="card-wrapper #{state.htmlclass}-wrapper"
-          - cache [state, state.annotations, state.comments, current_user] do
+          - cache [state, state.annotations, state.visible_comments, current_user] do
             = render "states/state", state: state, owner: @owner, project: @project
 
     .article-column.sp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,13 @@ Rails.application.routes.draw do
     get 'background', to: 'background#index', as: :background
     put 'background', to: 'background#update'
     resources :black_lists, except: [:edit, :update]
+    resources :project_comments, only: %i[index update destroy] do
+      resource :approval, only: [:create, :destroy], module: :project_comments
+      resource :spam, only: [:create, :destroy], module: :project_comments
+    end
+    namespace :project_comments do
+      resource :spam_batch, only: :create
+    end
   end
 
   root 'projects#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,13 @@ Rails.application.routes.draw do
     namespace :project_comments do
       resource :spam_batch, only: :create
     end
+    resources :card_comments, only: %i[index update destroy] do
+      resource :approval, only: [:create, :destroy], module: :card_comments
+      resource :spam, only: [:create, :destroy], module: :card_comments
+    end
+    namespace :card_comments do
+      resource :spam_batch, only: :create
+    end
     resources :spammers, only: %i[index destroy]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     namespace :project_comments do
       resource :spam_batch, only: :create
     end
+    resources :spammers, only: %i[index destroy]
   end
 
   root 'projects#index'

--- a/db/migrate/20250111062229_add_spam_to_comments.rb
+++ b/db/migrate/20250111062229_add_spam_to_comments.rb
@@ -1,0 +1,6 @@
+class AddSpamToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :project_comments, :spam, :boolean, default: false, null: false, after: :project_id, comment: "スパムコメントとして扱う"
+    add_column :card_comments, :spam, :boolean, default: false, null: false, after: :body, comment: "スパムコメントとして扱う"
+  end
+end

--- a/db/migrate/20250111062229_add_spam_to_comments.rb
+++ b/db/migrate/20250111062229_add_spam_to_comments.rb
@@ -1,6 +1,0 @@
-class AddSpamToComments < ActiveRecord::Migration[7.2]
-  def change
-    add_column :project_comments, :spam, :boolean, default: false, null: false, after: :project_id, comment: "スパムコメントとして扱う"
-    add_column :card_comments, :spam, :boolean, default: false, null: false, after: :body, comment: "スパムコメントとして扱う"
-  end
-end

--- a/db/migrate/20250111071932_add_status_to_comments.rb
+++ b/db/migrate/20250111071932_add_status_to_comments.rb
@@ -1,0 +1,6 @@
+class AddStatusToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :project_comments, :status, :integer, default: 0, null: false, after: :project_id, comment: "確認ステータス 0:未確認 1:承認済み 2:スパム"
+    add_column :card_comments, :status, :integer, default: 0, null: false, after: :body, comment: "確認ステータス 0:未確認 1:承認済み 2:スパム"
+  end
+end

--- a/db/migrate/20250112015153_create_spammers.rb
+++ b/db/migrate/20250112015153_create_spammers.rb
@@ -1,0 +1,10 @@
+class CreateSpammers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spammers do |t|
+      t.references :user, null: false, foreign_key: true, type: :integer, index: { unique: true }
+      t.timestamp :detected_at, null: true, comment: 'スパムとして検知された日時'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_062229) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_071932) do
   create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "content"
     t.string "attachable_type", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_062229) do
     t.integer "user_id", null: false
     t.integer "card_id", null: false
     t.text "body"
-    t.boolean "spam", default: false, null: false, comment: "スパムコメントとして扱う"
+    t.integer "status", default: 0, null: false, comment: "確認ステータス 0:未確認 1:承認済み 2:スパム"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["card_id"], name: "fk_rails_c8dff2752a"
@@ -204,7 +204,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_062229) do
     t.text "body", null: false
     t.integer "user_id", null: false
     t.integer "project_id", null: false
-    t.boolean "spam", default: false, null: false, comment: "スパムコメントとして扱う"
+    t.integer "status", default: 0, null: false, comment: "確認ステータス 0:未確認 1:承認済み 2:スパム"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_project_comments_on_project_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_071932) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_12_015153) do
   create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "content"
     t.string "attachable_type", null: false
@@ -238,6 +238,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_071932) do
     t.index ["updated_at"], name: "index_projects_updated_at"
   end
 
+  create_table "spammers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.timestamp "detected_at", comment: "スパムとして検知された日時"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_spammers_on_user_id", unique: true
+  end
+
   create_table "tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "user_id"
     t.integer "project_id"
@@ -285,6 +293,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_071932) do
   add_foreign_key "project_access_statistics", "projects"
   add_foreign_key "project_comments", "projects"
   add_foreign_key "project_comments", "users"
+  add_foreign_key "spammers", "users"
   add_foreign_key "tags", "projects"
   add_foreign_key "tags", "users", name: "fk_tags_user_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_28_091229) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_062229) do
   create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "content"
     t.string "attachable_type", null: false
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_28_091229) do
     t.integer "user_id", null: false
     t.integer "card_id", null: false
     t.text "body"
+    t.boolean "spam", default: false, null: false, comment: "スパムコメントとして扱う"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["card_id"], name: "fk_rails_c8dff2752a"
@@ -203,6 +204,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_28_091229) do
     t.text "body", null: false
     t.integer "user_id", null: false
     t.integer "project_id", null: false
+    t.boolean "spam", default: false, null: false, comment: "スパムコメントとして扱う"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_project_comments_on_project_id"

--- a/spec/controllers/admin/card_comments/approvals_controller_spec.rb
+++ b/spec/controllers/admin/card_comments/approvals_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Admin::CardComments::ApprovalsController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { card_comment_id: card_comment.id } }
+    let(:card_comment) { create(:card_comment) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントを承認して一覧に戻すこと" do
+        expect_any_instance_of(CardComment).to receive(:approve!)
+        is_expected.to redirect_to(admin_card_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { card_comment_id: card_comment.id } }
+    let(:card_comment) { create(:card_comment, :approved) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントの承認を取り消して一覧に戻すこと" do
+        expect_any_instance_of(CardComment).to receive(:unapprove!)
+        is_expected.to redirect_to(admin_card_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/card_comments/spam_batches_controller_spec.rb
+++ b/spec/controllers/admin/card_comments/spam_batches_controller_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Admin::CardComments::SpamBatchesController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { before: time.to_param } }
+    let!(:card_comment) { create(:card_comment, created_at: time) }
+    let(:time) { 1.hour.ago }
+
+    before do
+      # 変更されない
+      create(:card_comment, :approved, created_at: time - 1.second)
+      create(:card_comment, :unconfirmed, created_at: time + 1.second)
+    end
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "指定日時より古い未確認コメントをスパムにして一覧に戻すこと" do
+        expect_any_instance_of(CardComment).to receive(:mark_spam!).exactly(1).times
+        is_expected.to redirect_to(admin_card_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/card_comments/spams_controller_spec.rb
+++ b/spec/controllers/admin/card_comments/spams_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Admin::CardComments::SpamsController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { card_comment_id: card_comment.id } }
+    let(:card_comment) { create(:card_comment) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントをスパムにして一覧に戻すこと" do
+        expect_any_instance_of(CardComment).to receive(:mark_spam!)
+        is_expected.to redirect_to(admin_card_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { card_comment_id: card_comment.id } }
+    let(:card_comment) { create(:card_comment, :spam) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "スパムコメントの判定を取り消して一覧に戻すこと" do
+        expect_any_instance_of(CardComment).to receive(:unmark_spam!)
+        is_expected.to redirect_to(admin_card_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/card_comments_controller_spec.rb
+++ b/spec/controllers/admin/card_comments_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Admin::CardCommentsController, type: :controller do
+  let(:user) { create(:user, authority: authority) }
+
+  before { sign_in user }
+
+  describe "GET #index" do
+    subject { get :index }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it { is_expected.to be_successful }
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/project_comments/approvals_controller_spec.rb
+++ b/spec/controllers/admin/project_comments/approvals_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Admin::ProjectComments::ApprovalsController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { project_comment_id: project_comment.id } }
+    let(:project_comment) { create(:project_comment) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントを承認して一覧に戻すこと" do
+        expect_any_instance_of(ProjectComment).to receive(:approve!)
+        is_expected.to redirect_to(admin_project_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { project_comment_id: project_comment.id } }
+    let(:project_comment) { create(:project_comment, :approved) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントの承認を取り消して一覧に戻すこと" do
+        expect_any_instance_of(ProjectComment).to receive(:unapprove!)
+        is_expected.to redirect_to(admin_project_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/project_comments/spam_batches_controller_spec.rb
+++ b/spec/controllers/admin/project_comments/spam_batches_controller_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Admin::ProjectComments::SpamBatchesController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { before: time.to_param } }
+    let!(:project_comment) { create(:project_comment, created_at: time) }
+    let(:time) { 1.hour.ago }
+
+    before do
+      # 変更されない
+      create(:project_comment, :approved, created_at: time - 1.second)
+      create(:project_comment, :unconfirmed, created_at: time + 1.second)
+    end
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "指定日時より古い未確認コメントをスパムにして一覧に戻すこと" do
+        expect_any_instance_of(ProjectComment).to receive(:mark_spam!).exactly(1).times
+        is_expected.to redirect_to(admin_project_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/project_comments/spams_controller_spec.rb
+++ b/spec/controllers/admin/project_comments/spams_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Admin::ProjectComments::SpamsController, type: :controller do
+  let(:user) { create(:user, authority:) }
+
+  before { sign_in user }
+
+  describe "POST #create" do
+    subject { post :create, params: { project_comment_id: project_comment.id } }
+    let(:project_comment) { create(:project_comment) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "コメントをスパムにして一覧に戻すこと" do
+        expect_any_instance_of(ProjectComment).to receive(:mark_spam!)
+        is_expected.to redirect_to(admin_project_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { project_comment_id: project_comment.id } }
+    let(:project_comment) { create(:project_comment, :spam) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it "スパムコメントの判定を取り消して一覧に戻すこと" do
+        expect_any_instance_of(ProjectComment).to receive(:unmark_spam!)
+        is_expected.to redirect_to(admin_project_comments_path)
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/project_comments_controller_spec.rb
+++ b/spec/controllers/admin/project_comments_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Admin::ProjectCommentsController, type: :controller do
+  let(:user) { create(:user, authority: authority) }
+
+  before { sign_in user }
+
+  describe "GET #index" do
+    subject { get :index }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it { is_expected.to be_successful }
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/admin/spammers_controller_spec.rb
+++ b/spec/controllers/admin/spammers_controller_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Admin::SpammersController, type: :controller do
+  let(:user) { create(:user, authority: authority) }
+
+  before { sign_in user }
+
+  describe "GET #index" do
+    subject { get :index }
+    before do
+      create_list(:spammer, 3)
+    end
+
+    context "with authority" do
+      let(:authority) { "admin" }
+      it { is_expected.to be_successful }
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { id: spammer.id } }
+    let!(:spammer) { create(:spammer) }
+
+    context "with authority" do
+      let(:authority) { "admin" }
+
+      it do
+        expect { subject }.to change(Spammer, :count).by(-1)
+        is_expected.to redirect_to admin_spammers_path
+      end
+    end
+
+    context "without authority" do
+      let(:authority) { nil }
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end

--- a/spec/controllers/card_comments_controller_spec.rb
+++ b/spec/controllers/card_comments_controller_spec.rb
@@ -16,6 +16,22 @@ describe CardCommentsController, type: :controller do
                   .and render_template :create
       end
       it { expect{ subject }.to change{ CardComment.count }.by(1) }
+  
+      describe 'スパム投稿' do
+        context 'スパム投稿者でない場合' do
+          it '未確認コメントとして登録すること' do
+            expect{ subject }.to change(CardComment, :count).by(1).and change(Notification, :count).by(1)
+            expect(CardComment.last).to be_unconfirmed
+          end
+        end
+        context 'スパム投稿者の場合' do
+          before { user.spam_detect! }
+          it 'スパムコメントとして登録すること' do
+            expect{ subject }.to change(CardComment, :count).by(1).and change(Notification, :count).by(0)
+            expect(CardComment.last).to be_spam
+          end
+        end
+      end
     end
 
     context 'with invalid parameters' do

--- a/spec/controllers/project_comments_controller_spec.rb
+++ b/spec/controllers/project_comments_controller_spec.rb
@@ -24,6 +24,22 @@ describe ProjectCommentsController, type: :controller do
         subject
         expect(ProjectComment.last.user).to eq user
       end
+  
+      describe 'スパム投稿' do
+        context 'スパム投稿者でない場合' do
+          it '未確認コメントとして登録すること' do
+            expect{ subject }.to change(ProjectComment, :count).by(1)
+            expect(ProjectComment.last).to be_unconfirmed
+          end
+        end
+        context 'スパム投稿者の場合' do
+          before { user.spam_detect! }
+          it 'スパムコメントとして登録すること' do
+            expect{ subject }.to change(ProjectComment, :count).by(1)
+            expect(ProjectComment.last).to be_spam
+          end
+        end
+      end
     end
 
     context 'with invalid params' do

--- a/spec/controllers/project_comments_controller_spec.rb
+++ b/spec/controllers/project_comments_controller_spec.rb
@@ -28,14 +28,14 @@ describe ProjectCommentsController, type: :controller do
       describe 'スパム投稿' do
         context 'スパム投稿者でない場合' do
           it '未確認コメントとして登録すること' do
-            expect{ subject }.to change(ProjectComment, :count).by(1)
+            expect{ subject }.to change(ProjectComment, :count).by(1).and change(Notification, :count).by(1)
             expect(ProjectComment.last).to be_unconfirmed
           end
         end
         context 'スパム投稿者の場合' do
           before { user.spam_detect! }
           it 'スパムコメントとして登録すること' do
-            expect{ subject }.to change(ProjectComment, :count).by(1)
+            expect{ subject }.to change(ProjectComment, :count).by(1).and change(Notification, :count).by(0)
             expect(ProjectComment.last).to be_spam
           end
         end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -39,6 +39,66 @@ describe ProjectsController, type: :controller do
             it { is_expected.to have_http_status(:not_found) }
           end
         end
+
+        describe 'project comment visibility' do
+          context 'when the comment is spam' do
+            let!(:project_comment) { create(:project_comment, project:, spam: true) }
+
+            it 'does not show the comment' do
+              subject
+              expect(assigns(:project_comments)).to_not include(project_comment)
+            end
+          end
+          context 'when the comment is not spam' do
+            let!(:project_comment) { create(:project_comment, project:) }
+
+            it 'shows the comment' do
+              subject
+              expect(assigns(:project_comments)).to include(project_comment)
+            end
+          end
+        end
+
+        describe 'state comment visibility' do
+          let(:card) { create(:state, project:) }
+          context 'when the comment is spam' do
+            let!(:card_comment) { create(:card_comment, card:, spam: true) }
+
+            it 'does not show the comment' do
+              subject
+              expect(assigns(:states).map(&:visible_comments).flatten).to_not include(card_comment)
+            end
+          end
+          context 'when the comment is not spam' do
+            let!(:card_comment) { create(:card_comment, card:) }
+
+            it 'shows the comment' do
+              subject
+              expect(assigns(:states).map(&:visible_comments).flatten).to include(card_comment)
+            end
+          end
+        end
+
+        describe 'annotation comment visibility' do
+          let(:state) { create(:state, project:) }
+          let(:card) { create(:annotation, state:) }
+          context 'when the comment is spam' do
+            let!(:card_comment) { create(:card_comment, card:, spam: true) }
+
+            it 'does not show the comment' do
+              subject
+              expect(assigns(:states).map(&:annotations).flatten.map(&:visible_comments).flatten).to_not include(card_comment)
+            end
+          end
+          context 'when the comment is not spam' do
+            let!(:card_comment) { create(:card_comment, card:) }
+
+            it 'shows the comment' do
+              subject
+              expect(assigns(:states).map(&:annotations).flatten.map(&:visible_comments).flatten).to include(card_comment)
+            end
+          end
+        end
       end
       describe 'GET new' do
         before do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -42,7 +42,7 @@ describe ProjectsController, type: :controller do
 
         describe 'project comment visibility' do
           context 'when the comment is spam' do
-            let!(:project_comment) { create(:project_comment, project:, spam: true) }
+            let!(:project_comment) { create(:project_comment, :spam, project:) }
 
             it 'does not show the comment' do
               subject
@@ -62,7 +62,7 @@ describe ProjectsController, type: :controller do
         describe 'state comment visibility' do
           let(:card) { create(:state, project:) }
           context 'when the comment is spam' do
-            let!(:card_comment) { create(:card_comment, card:, spam: true) }
+            let!(:card_comment) { create(:card_comment, :spam, card:) }
 
             it 'does not show the comment' do
               subject
@@ -83,7 +83,7 @@ describe ProjectsController, type: :controller do
           let(:state) { create(:state, project:) }
           let(:card) { create(:annotation, state:) }
           context 'when the comment is spam' do
-            let!(:card_comment) { create(:card_comment, card:, spam: true) }
+            let!(:card_comment) { create(:card_comment, :spam, card:) }
 
             it 'does not show the comment' do
               subject

--- a/spec/factories/card_comments.rb
+++ b/spec/factories/card_comments.rb
@@ -3,13 +3,13 @@
 #
 # Table name: card_comments
 #
-#  id                             :integer          not null, primary key
-#  body                           :text(65535)
-#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
-#  created_at                     :datetime
-#  updated_at                     :datetime
-#  card_id                        :integer          not null
-#  user_id                        :integer          not null
+#  id                                                  :integer          not null, primary key
+#  body                                                :text(65535)
+#  status(確認ステータス 0:未確認 1:承認済み 2:スパム) :integer          default("unconfirmed"), not null
+#  created_at                                          :datetime
+#  updated_at                                          :datetime
+#  card_id                                             :integer          not null
+#  user_id                                             :integer          not null
 #
 # Indexes
 #
@@ -27,10 +27,13 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     association :user
     card
-    spam { false }
 
     trait :spam do
-      spam { true }
+      status { "spam" }
+    end
+
+    trait :approved do
+      status { "approved" }
     end
   end
 end

--- a/spec/factories/card_comments.rb
+++ b/spec/factories/card_comments.rb
@@ -3,12 +3,13 @@
 #
 # Table name: card_comments
 #
-#  id         :integer          not null, primary key
-#  body       :text(65535)
-#  created_at :datetime
-#  updated_at :datetime
-#  card_id    :integer          not null
-#  user_id    :integer          not null
+#  id                             :integer          not null, primary key
+#  body                           :text(65535)
+#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  card_id                        :integer          not null
+#  user_id                        :integer          not null
 #
 # Indexes
 #
@@ -26,5 +27,10 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     association :user
     card
+    spam { false }
+
+    trait :spam do
+      spam { true }
+    end
   end
 end

--- a/spec/factories/project_comments.rb
+++ b/spec/factories/project_comments.rb
@@ -2,13 +2,13 @@
 #
 # Table name: project_comments
 #
-#  id                             :bigint(8)        not null, primary key
-#  body                           :text(65535)      not null
-#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  project_id                     :integer          not null
-#  user_id                        :integer          not null
+#  id                                                  :bigint(8)        not null, primary key
+#  body                                                :text(65535)      not null
+#  status(確認ステータス 0:未確認 1:承認済み 2:スパム) :integer          default("unconfirmed"), not null
+#  created_at                                          :datetime         not null
+#  updated_at                                          :datetime         not null
+#  project_id                                          :integer          not null
+#  user_id                                             :integer          not null
 #
 # Indexes
 #
@@ -28,7 +28,11 @@ FactoryBot.define do
     project
 
     trait :spam do
-      spam { true }
+      status { "spam" }
+    end
+
+    trait :approved do
+      status { "approved" }
     end
   end
 end

--- a/spec/factories/project_comments.rb
+++ b/spec/factories/project_comments.rb
@@ -2,12 +2,13 @@
 #
 # Table name: project_comments
 #
-#  id         :bigint(8)        not null, primary key
-#  body       :text(65535)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  project_id :integer          not null
-#  user_id    :integer          not null
+#  id                             :bigint(8)        not null, primary key
+#  body                           :text(65535)      not null
+#  spam(スパムコメントとして扱う) :boolean          default(FALSE), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  project_id                     :integer          not null
+#  user_id                        :integer          not null
 #
 # Indexes
 #
@@ -25,5 +26,9 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     user
     project
+
+    trait :spam do
+      spam { true }
+    end
   end
 end

--- a/spec/factories/spammers.rb
+++ b/spec/factories/spammers.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: spammers
+#
+#  id                                      :bigint(8)        not null, primary key
+#  detected_at(スパムとして検知された日時) :datetime
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
+#  user_id                                 :integer          not null
+#
+# Indexes
+#
+#  index_spammers_on_user_id  (user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :spammer do
+    user
+    detected_at { Time.current }
+  end
+end

--- a/spec/models/project_comment_spec.rb
+++ b/spec/models/project_comment_spec.rb
@@ -28,4 +28,74 @@ describe ProjectComment do
       end
     end
   end
+
+  describe '#approve!' do
+    subject { project_comment.approve! }
+    let(:project_comment) { create(:project_comment) }
+
+    it do
+      expect { subject }.to change { project_comment.reload.status }.from('unconfirmed').to('approved')
+    end
+  end
+
+  describe '#unapprove!' do
+    subject { project_comment.unapprove! }
+    let(:project_comment) { create(:project_comment, status: status) }
+
+    context 'when status is unconfirmed' do
+      let(:status) { 'unconfirmed' }
+      it do
+        expect { subject }.not_to change { project_comment.reload.status }
+      end
+    end
+
+    context 'when status is approved' do
+      let(:status) { 'approved' }
+      it do
+        expect { subject }.to change { project_comment.reload.status }.from('approved').to('unconfirmed')
+      end
+    end
+
+    context 'when status is spam' do
+      let(:status) { 'spam' }
+      it do
+        expect { subject }.to raise_error(RuntimeError, "Can't unapprove spam comment")
+      end
+    end
+  end
+
+  describe '#mark_spam!' do
+    subject { project_comment.mark_spam! }
+    let(:project_comment) { create(:project_comment) }
+
+    it do
+      expect { subject }.to change { project_comment.reload.status }.from('unconfirmed').to('spam')
+    end
+  end
+
+  describe '#unmark_spam!' do
+    subject { project_comment.unmark_spam! }
+    let(:project_comment) { create(:project_comment, status: status) }
+
+    context 'when status is unconfirmed' do
+      let(:status) { 'unconfirmed' }
+      it do
+        expect { subject }.not_to change { project_comment.reload.status }
+      end
+    end
+
+    context 'when status is approved' do
+      let(:status) { 'approved' }
+      it do
+        expect { subject }.to raise_error(RuntimeError, "Can't unmark spam approved comment")
+      end
+    end
+
+    context 'when status is spam' do
+      let(:status) { 'spam' }
+      it do
+        expect { subject }.to change { project_comment.reload.status }.from('spam').to('unconfirmed')
+      end
+    end
+  end
 end

--- a/spec/models/project_comment_spec.rb
+++ b/spec/models/project_comment_spec.rb
@@ -74,6 +74,18 @@ describe ProjectComment do
       expect { subject }.to change { project_comment.reload.status }.from('unconfirmed').to('spam')
       expect(Notification.exists?(notification.id)).to be false
     end
+
+    context 'スパム投稿者として記録済みの場合' do
+      before { create(:spammer, user: comment_user) }
+
+      it { expect { subject }.to_not raise_error }
+      it { expect { subject }.to_not change(Spammer, :count) }
+    end
+
+    context 'スパム投稿者として記録されていない場合' do
+      it { expect { subject }.to_not raise_error }
+      it { expect { subject }.to change(Spammer, :count).by(1) }
+    end
   end
 
   describe '#unmark_spam!' do

--- a/spec/models/project_comment_spec.rb
+++ b/spec/models/project_comment_spec.rb
@@ -66,10 +66,13 @@ describe ProjectComment do
 
   describe '#mark_spam!' do
     subject { project_comment.mark_spam! }
-    let(:project_comment) { create(:project_comment) }
+    let(:comment_user) { create(:user) }
+    let(:project_comment) { create(:project_comment, user: comment_user) }
+    let!(:notification) { create(:notification, notifier: comment_user) }
 
-    it do
+    it "通知を削除してスパムとして記録すること" do
       expect { subject }.to change { project_comment.reload.status }.from('unconfirmed').to('spam')
+      expect(Notification.exists?(notification.id)).to be false
     end
   end
 

--- a/spec/models/spammer_spec.rb
+++ b/spec/models/spammer_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Spammer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #147 

## コメントの状態
未確認、承認済み、スパムの３つの状態を持つようにした。
管理者は未確認のコメントについて、承認済みまたはスパムのどちらかに変更する。
スパム状態のコメントは一般向け画面で非表示とする。

## 管理UI

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/170ed7dd-6362-4f96-af47-09d6b2605aaf" />

## プロジェクトコメント / カードコメント
投稿されたコメントは未確認状態で登録される。
管理者はそれぞれのコメントを承認できる。
未確認コメントをまとめてスパムとして登録できる。
![image](https://github.com/user-attachments/assets/8121ac67-d761-4546-9684-ff13b17cb726)

## スパム投稿者
コメントをスパムとして登録すると、コメントの投稿者をスパム投稿者として登録する。
スパム投稿者によるコメントは自動的にスパムとして登録される。
![image](https://github.com/user-attachments/assets/3b085f9c-3fbc-4a0d-97f2-094cfc67e9e3)

