### PR TITLE
トップページティッカー管理機能

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,47 @@
+class Admin::AnnouncementsController < Admin::ApplicationController
+  before_action :set_announcement, only: %i[show edit update destroy]
+
+  def index
+    @announcements = Announcement.all
+  end
+
+  def show; end
+
+  def new
+    @announcement = Announcement.new
+  end
+
+  def edit; end
+
+  def create
+    @announcement = Announcement.new(announcement_params)
+    if @announcement.save
+      redirect_to admin_announcements_path, notice: 'お知らせを作成しました。'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @announcement.update(announcement_params)
+      redirect_to admin_announcements_path, notice: 'お知らせを更新しました。'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @announcement.destroy
+    redirect_to admin_announcements_path, notice: 'お知らせを削除しました。'
+  end
+
+  private
+
+  def set_announcement
+    @announcement = Announcement.find(params[:id])
+  end
+
+  def announcement_params
+    params.require(:announcement).permit(:title_ja, :title_en, :content_ja, :content_en, :start_at, :end_at)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,6 +12,7 @@ class ProjectsController < ApplicationController
     @popular_projects = ProjectAccessStatistic.access_ranking.merge(projects).limit(10)
     @featured_groups = Rails.cache.fetch("Group.access_ranking", expires_in: 1.hour) { Group.access_ranking }
     @recent_projects = projects.order(updated_at: :desc).limit(12)
+    @announcements = Announcement.within_display_period
   end
 
   def show

--- a/app/helpers/admin/announcements_helper.rb
+++ b/app/helpers/admin/announcements_helper.rb
@@ -1,0 +1,2 @@
+module Admin::AnnouncementsHelper
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id                         :bigint(8)        not null, primary key
+#  content_en(本文（英語）)   :text(65535)      not null
+#  content_ja(本文（日本語）) :text(65535)      not null
+#  end_at(掲載終了日時)       :datetime         not null
+#  start_at(掲載開始日時)     :datetime         not null
+#  title_en(見出し（英語）)   :string(255)      not null
+#  title_ja(見出し（日本語）) :string(255)      not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+class Announcement < ApplicationRecord
+  validates :title_ja, presence: true
+  validates :title_en, presence: true
+  validates :content_ja, presence: true
+  validates :content_en, presence: true
+  validates :start_at, presence: true
+  validates :end_at, presence: true
+  scope :within_display_period, -> (now: Time.current) do
+    where("start_at <= :now AND end_at > :now", now:)
+  end
+end

--- a/app/views/admin/announcements/_form.html.slim
+++ b/app/views/admin/announcements/_form.html.slim
@@ -1,0 +1,25 @@
+/ local_variables: form
+
+div.form-group
+  = form.label :title_ja
+  = form.text_field :title_ja, class: 'form-control'
+
+div.form-group
+  = form.label :title_en
+  = form.text_field :title_en, class: 'form-control'
+
+div.form-group
+  = form.label :content_ja
+  = form.text_area :content_ja, class: 'form-control'
+
+div.form-group
+  = form.label :content_en
+  = form.text_area :content_en, class: 'form-control'
+
+div.form-group
+  = form.label :start_at
+  = form.datetime_field :start_at, class: 'form-control'
+
+div.form-group
+  = form.label :end_at
+  = form.datetime_field :end_at, class: 'form-control'

--- a/app/views/admin/announcements/edit.html.slim
+++ b/app/views/admin/announcements/edit.html.slim
@@ -1,0 +1,14 @@
+#admin-announcements-edit
+  h2.h2 edit announcement
+
+  - if @announcement.errors.any?
+    .alert.alert-danger
+      h6.h6.text-bold お知らせを登録できませんでした
+      ul
+        - @announcement.errors.full_messages.each do |message|
+          li = message
+
+  = form_with(model: [:admin, @announcement], local: true) do |form|
+    = render partial: "form", locals: { form: }
+
+    = form.submit '更新', class: 'btn btn-primary'

--- a/app/views/admin/announcements/index.html.slim
+++ b/app/views/admin/announcements/index.html.slim
@@ -1,0 +1,27 @@
+#admin-announcements-index
+  h2.h2 Announcements
+
+  - flash.each do |key, message|
+    div class="alert alert-#{key}"
+      = message
+
+  div style="margin: 30px auto"
+    = link_to '新規お知らせ', new_admin_announcement_path, class: "btn btn-primary btn-sm"
+
+  table.table
+    thead
+      tr
+        th = Announcement.human_attribute_name :title_ja
+        th = Announcement.human_attribute_name :start_at
+        th = Announcement.human_attribute_name :end_at
+        th Manage
+    tbody
+      - @announcements.each do |announcement|
+        tr
+          td = announcement.title_ja.html_safe
+          td =l announcement.start_at
+          td =l announcement.end_at
+          td
+            = link_to '表示', admin_announcement_path(announcement), class: 'btn btn-info'
+            = link_to '編集', edit_admin_announcement_path(announcement), class: 'btn btn-warning'
+            = link_to '削除', admin_announcement_path(announcement), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-danger'

--- a/app/views/admin/announcements/new.html.slim
+++ b/app/views/admin/announcements/new.html.slim
@@ -1,0 +1,14 @@
+#admin-announcements-new
+  h2.h2 New announcement
+
+  - if @announcement.errors.any?
+    .alert.alert-danger
+      h6.h6.text-bold お知らせを登録できませんでした
+      ul
+        - @announcement.errors.full_messages.each do |message|
+          li = message
+
+  = form_with(model: [:admin, @announcement], local: true) do |form|
+    = render partial: "form", locals: { form: }
+
+    = form.submit '登録', class: 'btn btn-primary'

--- a/app/views/admin/announcements/show.html.slim
+++ b/app/views/admin/announcements/show.html.slim
@@ -1,0 +1,42 @@
+#admin-announcements-show
+  h2.h2 Manage announcement
+
+  table.table
+    tr
+      th
+        = Announcement.human_attribute_name :title_ja
+      td
+        = @announcement.title_ja.html_safe
+    tr
+      th
+        = Announcement.human_attribute_name :title_en
+      td
+        = @announcement.title_en.html_safe
+    tr
+      th
+        = Announcement.human_attribute_name :content_ja
+      td
+        = @announcement.content_ja.html_safe
+    tr
+      th
+        = Announcement.human_attribute_name :content_en
+      td
+        = @announcement.content_en.html_safe
+    tr
+      th
+        = Announcement.human_attribute_name :start_at
+      td
+        =l @announcement.start_at
+    tr
+      th
+        = Announcement.human_attribute_name :end_at
+      td
+        =l @announcement.end_at
+    tr
+      th
+        = Announcement.human_attribute_name :created_at
+      td
+        =l @announcement.created_at
+
+  = link_to '編集', edit_admin_announcement_path(@announcement), class: 'btn btn-warning'
+  = link_to '削除', admin_announcement_path(@announcement), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-danger'

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -9,3 +9,4 @@
     = link_to('プロジェクトコメント', admin_project_comments_path, class: 'nav-link')
     = link_to('カードコメント', admin_card_comments_path, class: 'nav-link')
     = link_to('スパム投稿者', admin_spammers_path, class: 'nav-link')
+    = link_to('お知らせ', admin_announcements_path, class: 'nav-link')

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -1,0 +1,15 @@
+/ local_variables: announcement
+
+#ticker style="background: white; padding: 1rem 0"
+  .container style="text-align: center; border: 2px solid red; max-width: 1000px; margin: 0 auto;"
+    .inner style="margin: 1rem"
+      .lang-jp
+        h2 style="margin-bottom: 1rem; font-weight: bold; font-size: 18px;"
+          = announcement.title_ja.html_safe
+        p style="line-height: 1.5rem"
+          = announcement.content_ja.html_safe
+      .lang-en
+        h2 style="margin-bottom: 1rem; font-weight: bold; font-size: 18px;"
+          = announcement.title_en.html_safe
+        p style="line-height: 1.5rem"
+          = announcement.content_en.html_safe

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -39,6 +39,7 @@
 
     = render partial: "introduction"
 
+  = render @announcements
   = render partial: "howto_use_fabble"
   = render partial: "popular_projects"
   = render partial: "featured_groups"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       resource :spam_batch, only: :create
     end
     resources :spammers, only: %i[index destroy]
+    resources :announcements
   end
 
   root 'projects#index'

--- a/db/migrate/20250117083917_create_announcements.rb
+++ b/db/migrate/20250117083917_create_announcements.rb
@@ -1,0 +1,14 @@
+class CreateAnnouncements < ActiveRecord::Migration[7.2]
+  def change
+    create_table :announcements, comment: "お知らせ" do |t|
+      t.string :title_ja, null: false, comment: "見出し（日本語）"
+      t.string :title_en, null: false, comment: "見出し（英語）"
+      t.text :content_ja, null: false, comment: "本文（日本語）"
+      t.text :content_en, null: false, comment: "本文（英語）"
+      t.datetime :start_at, null: false, comment: "掲載開始日時"
+      t.datetime :end_at, null: false, comment: "掲載終了日時"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_12_015153) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_17_083917) do
+  create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "お知らせ", force: :cascade do |t|
+    t.string "title_ja", null: false, comment: "見出し（日本語）"
+    t.string "title_en", null: false, comment: "見出し（英語）"
+    t.text "content_ja", null: false, comment: "本文（日本語）"
+    t.text "content_en", null: false, comment: "本文（英語）"
+    t.datetime "start_at", null: false, comment: "掲載開始日時"
+    t.datetime "end_at", null: false, comment: "掲載終了日時"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "content"
     t.string "attachable_type", null: false

--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -1,0 +1,184 @@
+RSpec.describe Admin::AnnouncementsController, type: :controller do
+  let(:authority) { raise "Define authority in each context" }
+  before { sign_in create(:user, authority: authority) }
+
+  describe 'GET #index' do
+    let(:announcement) { create(:announcement) }
+    context "with authority" do
+      let(:authority) { "admin" }
+      it 'returns a success response' do
+        get :index
+        expect(response).to be_successful
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    let(:announcement) { create(:announcement) }
+    context "with authority" do
+      let(:authority) { "admin" }
+      it 'returns a success response' do
+        get :show, params: { id: announcement.to_param }
+        expect(response).to be_successful
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        get :show, params: { id: announcement.to_param }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    context "with authority" do
+      let(:authority) { "admin" }
+      it 'returns a success response' do
+        get :new
+        expect(response).to be_successful
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        get :new
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:announcement) { create(:announcement) }
+    context "with authority" do
+      let(:authority) { "admin" }
+      it 'returns a success response' do
+        get :edit, params: { id: announcement.to_param }
+        expect(response).to be_successful
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        get :edit, params: { id: announcement.to_param }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context "with authority" do
+      let(:authority) { "admin" }
+      context 'with valid params' do
+        let(:valid_attributes) { attributes_for(:announcement) }
+
+        it 'creates a new Announcement' do
+          expect {
+            post :create, params: { announcement: valid_attributes }
+          }.to change(Announcement, :count).by(1)
+        end
+
+        it 'redirects to the announcements list' do
+          post :create, params: { announcement: valid_attributes }
+          expect(response).to redirect_to(admin_announcements_path)
+        end
+      end
+
+      context 'with invalid params' do
+        let(:invalid_attributes) { attributes_for(:announcement, title_ja: nil) }
+
+        it 'does not create a new Announcement' do
+          expect {
+            post :create, params: { announcement: invalid_attributes }
+          }.not_to change(Announcement, :count)
+        end
+
+        it 'renders the new template' do
+          post :create, params: { announcement: invalid_attributes }
+          expect(response).to render_template(:new)
+        end
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        post :create, params: { announcement: attributes_for(:announcement) }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:announcement) { create(:announcement) }
+    context "with authority" do
+      let(:authority) { "admin" }
+      context 'with valid params' do
+        let(:new_attributes) { { title_ja: 'New Title' } }
+
+        it 'updates the requested announcement' do
+          put :update, params: { id: announcement.to_param, announcement: new_attributes }
+          announcement.reload
+          expect(announcement.title_ja).to eq('New Title')
+        end
+
+        it 'redirects to the announcements list' do
+          put :update, params: { id: announcement.to_param, announcement: new_attributes }
+          expect(response).to redirect_to(admin_announcements_path)
+        end
+      end
+
+      context 'with invalid params' do
+        let(:invalid_attributes) { { title_ja: nil } }
+
+        it 'does not update the announcement' do
+          put :update, params: { id: announcement.to_param, announcement: invalid_attributes }
+          announcement.reload
+          expect(announcement.title_ja).not_to be_nil
+        end
+
+        it 'renders the edit template' do
+          put :update, params: { id: announcement.to_param, announcement: invalid_attributes }
+          expect(response).to render_template(:edit)
+        end
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        put :update, params: { id: announcement.to_param, announcement: { title_ja: 'New Title' } }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:announcement) { create(:announcement) }
+    context "with authority" do
+      let(:authority) { "admin" }
+      it 'destroys the requested announcement' do
+        expect {
+          delete :destroy, params: { id: announcement.to_param }
+        }.to change(Announcement, :count).by(-1)
+      end
+
+      it 'redirects to the announcements list' do
+        delete :destroy, params: { id: announcement.to_param }
+        expect(response).to redirect_to(admin_announcements_path)
+      end
+    end
+    context "without authority" do
+      let(:authority) { nil }
+      it 'redirects to the root path' do
+        delete :destroy, params: { id: announcement.to_param }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -17,6 +17,28 @@ describe ProjectsController, type: :controller do
 
       it { is_expected.to render_template :index }
     end
+
+    describe 'Announcements' do
+      let!(:announcement) { create(:announcement, start_at: Time.current, end_at: 1.hour.from_now) }
+      it "shows the announcement" do
+        get :index
+        expect(assigns(:announcements)).to include(announcement)
+      end
+      context 'when the announcement is expired' do
+        let!(:announcement) { create(:announcement, start_at: 1.hour.ago, end_at: 1.second.ago) }
+        it "does not show the announcement" do
+          get :index
+          expect(assigns(:announcements)).not_to include(announcement)
+        end
+      end
+      context 'when the announcement is not started' do
+        let!(:announcement) { create(:announcement, start_at: 1.hour.from_now, end_at: 2.hours.from_now) }
+        it "does not show the announcement" do
+          get :index
+          expect(assigns(:announcements)).not_to include(announcement)
+        end
+      end
+    end
   end
 
   %w[user group].each do |owner_type|

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id                         :bigint(8)        not null, primary key
+#  content_en(本文（英語）)   :text(65535)      not null
+#  content_ja(本文（日本語）) :text(65535)      not null
+#  end_at(掲載終了日時)       :datetime         not null
+#  start_at(掲載開始日時)     :datetime         not null
+#  title_en(見出し（英語）)   :string(255)      not null
+#  title_ja(見出し（日本語）) :string(255)      not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+FactoryBot.define do
+  factory :announcement do
+    title_ja { "<b>MyString</b>" }
+    title_en { "<b>MyString</b>" }
+    content_ja { "MyText<br>MyText" }
+    content_en { "MyText<br>MyText" }
+    start_at { Time.current }
+    end_at { 1.hours.from_now }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Announcement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #148 

管理画面から
タイトル
内容
掲載期間
を指定してお知らせを登録できる。

![image](https://github.com/user-attachments/assets/20311026-a0a0-4786-b68d-aa1e820dfcb5)
![image](https://github.com/user-attachments/assets/258772e9-8385-41d6-a565-0c33016d9b59)

登録したお知らせは掲載期間の間トップページに掲載される。
タイトルと内容は日本語と英語それぞれ登録できる。

![image](https://github.com/user-attachments/assets/b4db8e05-5cd1-446e-8cc5-22d6b4c201a9)
![image](https://github.com/user-attachments/assets/13b43410-f18a-4212-bdc1-ca1ec75b12f9)
