### PR TITLE
Dockerコンテナを userns-remap で動作させるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ public/javascripts/dist/
 app/assets/build
 
 /.kamal/secrets-common
+/config/deploy.*.yml
 
 /config/credentials/development.key
 /config/credentials/production.key

--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -1,10 +1,28 @@
 #!/bin/sh
 
-kamal proxy boot_config set \
---docker_options \
-  log-driver=syslog \
-  log-opt=syslog-address=udp://127.0.0.1:514 \
-  log-opt=syslog-facility=daemon \
-  log-opt=tag=proxy \
-  log-opt=syslog-format=rfc5424 \
---log-max-size=""
+# kamal proxy コンテナの起動オプションを設定
+# - ホストの rsyslog にログを出力
+# - ログのフォーマットを RFC5424 にする
+# - userns=host でホストのユーザ名前空間を利用
+
+if [ -z "$KAMAL_DESTINATION" ]; then
+  kamal proxy boot_config set \
+    --docker_options \
+      log-driver=syslog \
+      log-opt=syslog-address=udp://127.0.0.1:514 \
+      log-opt=syslog-facility=daemon \
+      log-opt=tag=proxy \
+      log-opt=syslog-format=rfc5424 \
+      userns=host \
+    --log-max-size=""
+else
+  kamal proxy -d "$KAMAL_DESTINATION" boot_config set \
+    --docker_options \
+      log-driver=syslog \
+      log-opt=syslog-address=udp://127.0.0.1:514 \
+      log-opt=syslog-facility=daemon \
+      log-opt=tag=proxy \
+      log-opt=syslog-format=rfc5424 \
+      userns=host \
+    --log-max-size=""
+fi

--- a/config/crontab
+++ b/config/crontab
@@ -1,3 +1,3 @@
-0 5 * * * sudo -u deploy bash -c 'source /tmp/cron.env.sh && cd /app && bundle exec rails backup:delete' > /proc/1/fd/1 2>&1
-30 0 * * * sudo -u deploy bash -c 'source /tmp/cron.env.sh && cd /app && bundle exec rails statistic:daily' > /proc/1/fd/1 2>&1
-0 * * * * sudo -u deploy bash -c 'source /tmp/cron.env.sh && cd /app && bundle exec rails runner "Rails.cache.clear"' > /proc/1/fd/1 2>&1
+0 5 * * * . /etc/profile; cd /app && bundle exec rails backup:delete > /proc/1/fd/1 2>&1
+30 0 * * * . /etc/profile; cd /app && bundle exec rails statistic:daily > /proc/1/fd/1 2>&1
+0 * * * * . /etc/profile; cd /app && bundle exec rails runner "Rails.cache.clear" > /proc/1/fd/1 2>&1

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -7,13 +7,9 @@ image: xxxxxxxx/gitfab2
 # Deploy to these servers.
 servers:
   web:
-    hosts:
-      - 160.16.100.129
-    cmd: sudo -E -H -u deploy bash -c "bundle exec unicorn_rails -c config/unicorn.rb"
+    cmd: bundle exec unicorn_rails -c config/unicorn.rb
   job:
-    hosts:
-      - 160.16.100.129
-    cmd: sudo -E -H -u deploy bash -c "bin/delayed_job run"
+    cmd: bin/delayed_job run
     logging:
       driver: syslog
       options:
@@ -22,10 +18,8 @@ servers:
         tag: "job"
         syslog-format: rfc5424
   cron:
-    hosts:
-      - 160.16.100.129
     cmd:
-      bash -c "env | grep -v HOME | awk '{ print \"export \" \$0 }' > /tmp/cron.env.sh; cat config/crontab | crontab - && cron -f"
+      bash -c "eval \$(printenv | awk -F= '{print \"export \" \"\\\"\"\$1\"\\\"\"\"=\"\"\\\"\"\$2\"\\\"\" }' >> /etc/profile); cat config/crontab | crontab - && cron -f"
     logging:
       driver: syslog
       options:
@@ -39,8 +33,6 @@ servers:
 #
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption. 
 proxy:
-  ssl: true
-  host: fabble.cc
   # Proxy connects to your container on port 80 by default.
   app_port: 3000
   healthcheck:
@@ -70,9 +62,6 @@ builder:
   context: .
   dockerfile: docker/Dockerfile.prod
   args:
-    USERNAME: deploy
-    USER_UID: 1001
-    USER_GID: 1001
     WORKDIR: /app
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
@@ -99,12 +88,6 @@ env:
 #
 aliases:
   apps: server exec docker exec kamal-proxy kamal-proxy list
-
-# Use a different ssh user than root
-#
-ssh:
-  user: deploy
-  port: 22
 
 # Use a persistent storage volume.
 #
@@ -137,7 +120,6 @@ logging:
 accessories:
   db:
     image: mysql:8.0
-    host: 160.16.100.129
     port: "127.0.0.1:3306:3306"
     env:
       clear:

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -8,7 +8,7 @@ RUN apt-get update -qq \
     nodejs npm vim \
     povray povray-includes \
     imagemagick libvips libimage-exiftool-perl \
-    cron sudo \
+    cron \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -60,15 +60,4 @@ FROM base
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build $WORKDIR $WORKDIR
 
-ARG USERNAME=ruby
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $USERNAME && \
-    useradd -m --shell /bin/bash --uid $USER_UID --gid $USER_GID $USERNAME && \
-    mkdir public/uploads && \
-    chown -R $USERNAME:$USERNAME db log tmp public/uploads
-
-#USER $USERNAME:$USERNAME
-
 EXPOSE 3000
-#CMD ["bundle", "exec", "unicorn_rails", "-c", "config/unicorn.rb"]


### PR DESCRIPTION
デプロイ設定の改善

- kamal.yml を変更せずにdeployできるようにする
  - デプロイ先サーバーやイメージリポジトリを destination オプションで指定するようにした
- userns-remap を有効にしたDockerホストに対応した
- コンテナ内の sudo を不要にしてコマンドをシンプルにした
