### PR TITLE
feat(admin): スパム認定ボタンの視認性を向上

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -10,8 +10,13 @@ class Admin::ProjectsController < Admin::ApplicationController
   def show; end
 
   def destroy
-    @project.soft_destroy!
-    redirect_to admin_projects_path
+    result = SpamDesignationService.call([@project])
+
+    if result.failed.empty?
+      redirect_to admin_projects_path, notice: 'プロジェクトをスパム認定しました'
+    else
+      redirect_to admin_projects_path, alert: 'スパム認定に失敗しました'
+    end
   end
 
   def batch_spam

--- a/app/views/admin/projects/show.html.slim
+++ b/app/views/admin/projects/show.html.slim
@@ -40,4 +40,4 @@
         = @project.original ? link_to(@project.original.title_with_owner_name, [:admin, @project]) : '-'
 
 
-  = button_to('削除', admin_project_path(@project.id), method: :delete, data: {confirm: '本当に削除しますか？'})
+  = button_to('スパム認定', admin_project_path(@project.id), method: :delete, class: 'btn btn-danger btn-lg', data: {confirm: '本当にスパム認定しますか？'})


### PR DESCRIPTION
プロジェクト管理のプロジェクト詳細画面において

- プロジェクトの（論理）削除を「スパム認定」に統一
  - これまでの論理削除に加えて、オーナーをスパム投稿者として登録する
- ボタンの視認性を向上

| before | after |
| --- | --- |
| <img width="1587" height="676" alt="image" src="https://github.com/user-attachments/assets/f5400d45-5de3-4a12-9b55-4ea4291a7b56" /> | <img width="1588" height="726" alt="image" src="https://github.com/user-attachments/assets/758c058e-75f6-4d16-9435-6a380611a9f7" /> |